### PR TITLE
feat(0.7.4): delivery modes + lazy pull ring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,15 @@
 - `CAP_DELIVERY_MODE` + pure helpers `delivery_mode_uses_callback_iq` / `_uses_read`
 - `read()` returns `ERR_UNSUPPORTED` in CALLBACK-only mode
 
+### Fixed (CodeRabbit on PR #6)
+
+- Serialize `ensure_pull_ring` on the handle lock; fail-closed teardown of partial rings
+  (no double-alloc race between delivery task and `read()`)
+
 ### Docs / process (from 0.7.3 review gap work)
 
 - Full API reference, Kconfig/troubleshooting/examples, soak template, SCOPE, licensing
+- Legacy `struct_size` fallback for delivery fields documented; versioning table through 0.7.4
 
 ## 0.7.3 (2026-08-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,22 @@
 
 ## Unreleased
 
-### Docs / process (review gap closure)
+## 0.7.4 (2026-08-13)
 
-- **Full API reference:** `docs/API_REFERENCE.md` (parameters, returns, examples)
-- Kconfig, troubleshooting, examples, soak procedure + lab template
-- Intentional hardware scope (`docs/SCOPE.md`), runtime constants doc
-- Commercial licensing process expanded (`LICENSING.md`)
-- Review gap map: `docs/REVIEW_GAPS_2026-08.md`
-- GitHub Release for `v0.7.3` + tracking issues for open lab work
+### Added
+
+- **Delivery modes** (`config.delivery_mode`): `BOTH` (default) | `CALLBACK` | `READ`
+  - `CALLBACK`: `EVT_IQ_BLOCK` only — no large pull-ring allocation
+  - `READ`: blocking `read()` only — no `EVT_IQ_BLOCK`
+  - `BOTH`: previous behavior
+- **Lazy pull ring:** buffer allocated on first IQ push or first `read()` when mode uses read
+- Optional `config.pull_ring_bytes` (0 = auto; even, 1 KiB…1 MiB)
+- `CAP_DELIVERY_MODE` + pure helpers `delivery_mode_uses_callback_iq` / `_uses_read`
+- `read()` returns `ERR_UNSUPPORTED` in CALLBACK-only mode
+
+### Docs / process (from 0.7.3 review gap work)
+
+- Full API reference, Kconfig/troubleshooting/examples, soak template, SCOPE, licensing
 
 ## 0.7.3 (2026-08-12)
 

--- a/PROJECT_TRUTH.md
+++ b/PROJECT_TRUTH.md
@@ -7,7 +7,7 @@ Same discipline as [TheOrc PROJECT_TRUTH](https://github.com/hardcoreerik/TheOrc
 claims need evidence labels; oversell is a bug; retract rather than spin.
 
 Snapshot date: **2026-08-13**  
-Version: **0.7.3** (async retune from callback — not production-ready)  
+Version: **0.7.4** (delivery modes + lazy pull ring — not production-ready)  
 Local repo: `F:\Ai\ESP_RTL_SDR\`  
 Remote: **https://github.com/hardcoreerik/esp-rtl-sdr**  
 Open-source honesty: [docs/AI_DEVELOPMENT_DISCLOSURE.md](docs/AI_DEVELOPMENT_DISCLOSURE.md) ·
@@ -82,6 +82,7 @@ Product vision: **`docs/VISION.md`**. Silicon / DS map: **`docs/SILICON.md`**.
 | Gain / bias public API | **Implemented (stubs)** | Returns UNSUPPORTED; CAP bits **off** |
 | set/get center freq, rate, ppm | **Implemented** | |
 | Sync `read()` | **Implemented** | |
+| Delivery modes BOTH/CALLBACK/READ + lazy pull ring | **Implemented** | 0.7.4; CAP_DELIVERY_MODE |
 | Multi-device select | **Implemented** | |
 | Blog V4 filter `0bda:2838` | **Implemented** | |
 | Dual-core USB/delivery | **Implemented** | |

--- a/PROJECT_TRUTH.md
+++ b/PROJECT_TRUTH.md
@@ -105,6 +105,10 @@ Product vision: **`docs/VISION.md`**. Silicon / DS map: **`docs/SILICON.md`**.
 | **0.5.0** | Rename + Phase 1 freq/rate/read |
 | **0.6.0** | Phase 2: expanded rates list + ppm + multi-device |
 | **0.7.0** | Continuous rates + need + health + passport + docs (vision/silicon/lab) |
+| **0.7.1** | Host tests / CI spine expansion |
+| **0.7.2** | Runtime hardening (STARTING, join, ring transactional, Kconfig) |
+| **0.7.3** | True async retune from event callback + `EVT_RETUNED` |
+| **0.7.4** | Delivery modes BOTH/CALLBACK/READ + lazy pull ring |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Make an RTL-SDR Blog V4 a first-class peripheral on ESP32-P4** — continuous I/Q over USB Host, with a real embedded driver API.
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
-![Status](https://img.shields.io/badge/version-0.7.3-green)
+![Status](https://img.shields.io/badge/version-0.7.4-green)
 [![GitHub](https://img.shields.io/badge/github-esp--rtl--sdr-black)](https://github.com/hardcoreerik/esp-rtl-sdr)
 ![Target](https://img.shields.io/badge/ESP32--P4-HS_USB-green)
 

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -63,7 +63,7 @@ Review-driven (pause Phase 3 hardware for one release):
 - [x] Component `targets: esp32p4`
 - [x] ESP-IDF P4 compile CI (`idf-p4-build` on 5.3.2 + 5.4.1)
 - [x] True async retune from callback (queue + delivery apply + EVT_RETUNED)
-- [ ] Delivery CALLBACK/READ/BOTH + lazy pull ring
+- [x] Delivery CALLBACK/READ/BOTH + lazy pull ring (**0.7.4**)
 - [ ] Lab soak evidence from this tree (procedure ready: `docs/SOAK.md`)
 
 See `docs/HARDENING_0_7_2.md`.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,7 +1,7 @@
 # esp_rtl_sdr public API — design contract
 
 **Header:** [`include/esp_rtl_sdr.h`](../include/esp_rtl_sdr.h)  
-**Version:** 0.7.3  
+**Version:** 0.7.4  
 **Full parameter / return / example reference:** [`API_REFERENCE.md`](API_REFERENCE.md)
 
 This document is the **design contract** (invariants, threading, ABI growth).  
@@ -118,7 +118,7 @@ Prefer component codes over generic `INVALID_STATE` when the app can branch:
 
 ---
 
-## Capabilities (0.7.3 binary)
+## Capabilities (0.7.4 binary)
 
 | Flag | Status |
 |---|---|
@@ -134,6 +134,7 @@ Prefer component codes over generic `INVALID_STATE` when the app can branch:
 | `NEED` | On; `apply_need` |
 | `HEALTH` | On; `get_health` |
 | `PASSPORT` | On; `probe_rates` |
+| `DELIVERY_MODE` | On; `config.delivery_mode` BOTH/CALLBACK/READ |
 | `IQ_ACQUIRE` | Off |
 | `GAIN` | Off until measured capture |
 | `BIAS_TEE` / `DIRECT_SAMPLING` | Reserved off |

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -542,6 +542,13 @@ Payload of `EVT_ERROR`.
 | `delivery_mode` | `BOTH` | `BOTH` / `CALLBACK` / `READ` (0.7.4+) |
 | `pull_ring_bytes` | 0 = auto | Even, 1 KiB…1 MiB if set; lazy alloc when mode uses read |
 
+**Legacy `struct_size`:** If the app was compiled against a header that ends at
+`usb_task_core_id` (or any size that omits the new trailing fields),
+`install` / `config_validate` copy only `struct_size` bytes over defaults — so
+**`delivery_mode` stays `BOTH`** and **`pull_ring_bytes` stays `0` (auto)**. Apps
+need a current header (and full `struct_size`) to select CALLBACK/READ or a
+custom pull size.
+
 ### Delivery modes (0.7.4)
 
 | Mode | `EVT_IQ_BLOCK` | `read()` | Pull-ring RAM |

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # esp_rtl_sdr — API Reference
 
-> **Version tracked:** `0.7.3` (see `ESP_RTL_SDR_VERSION_*` in [`include/esp_rtl_sdr.h`](../include/esp_rtl_sdr.h))  
+> **Version tracked:** `0.7.4` (see `ESP_RTL_SDR_VERSION_*` in [`include/esp_rtl_sdr.h`](../include/esp_rtl_sdr.h))  
 > **Header of record:** [`include/esp_rtl_sdr.h`](../include/esp_rtl_sdr.h)  
 > **Design contract (invariants, ABI growth):** [`API.md`](API.md)  
 > **What works on hardware right now:** [`../PROJECT_TRUTH.md`](../PROJECT_TRUTH.md) wins on any claim conflict.
@@ -296,7 +296,7 @@ uint32_t esp_rtl_sdr_get_capabilities(void);
 | **Returns** | Bitmask of `esp_rtl_sdr_cap_t` for **this binary** |
 | **Notes** | No handle required. CAP bits track **implemented** paths only. |
 
-### Capability map (0.7.3)
+### Capability map (0.7.4)
 
 | Flag | Bit | Status | Meaning |
 |---|---|---|---|
@@ -316,6 +316,7 @@ uint32_t esp_rtl_sdr_get_capabilities(void);
 | `ESP_RTL_SDR_CAP_HEALTH` | 13 | **On** | `get_health` / `EVT_HEALTH` |
 | `ESP_RTL_SDR_CAP_PASSPORT` | 14 | **On** | `probe_rates` |
 | `ESP_RTL_SDR_CAP_GAIN` | 15 | **Off** | Until Phase 3 capture |
+| `ESP_RTL_SDR_CAP_DELIVERY_MODE` | 16 | **On** | `config.delivery_mode` |
 
 ```c
 const uint32_t need = ESP_RTL_SDR_CAP_STREAM | ESP_RTL_SDR_CAP_SYNC_READ;
@@ -538,6 +539,27 @@ Payload of `EVT_ERROR`.
 | `iq_acquire_mode` | `false` | Ignored until CAP_IQ_ACQUIRE |
 | `usb_task_priority` | 0 = driver default | |
 | `usb_task_core_id` | 0xFF = no affinity | 0, 1, or 0xFF |
+| `delivery_mode` | `BOTH` | `BOTH` / `CALLBACK` / `READ` (0.7.4+) |
+| `pull_ring_bytes` | 0 = auto | Even, 1 KiB…1 MiB if set; lazy alloc when mode uses read |
+
+### Delivery modes (0.7.4)
+
+| Mode | `EVT_IQ_BLOCK` | `read()` | Pull-ring RAM |
+|---|---|---|---|
+| `DELIVERY_BOTH` (default) | Yes | Yes | Lazy on first IQ or `read` |
+| `DELIVERY_CALLBACK` | Yes | `ERR_UNSUPPORTED` | **Never** |
+| `DELIVERY_READ` | No | Yes | Lazy on first IQ or `read` |
+
+Other events (`STARTED`, `RETUNED`, `HEALTH`, `ERROR`, …) still use `event_cb` when set.
+
+```c
+cfg.delivery_mode = ESP_RTL_SDR_DELIVERY_CALLBACK; /* no pull ring */
+/* or */
+cfg.delivery_mode = ESP_RTL_SDR_DELIVERY_READ;     /* no IQ callbacks */
+cfg.pull_ring_bytes = 256 * 1024;                  /* optional size */
+```
+
+Helpers: `esp_rtl_sdr_delivery_mode_uses_callback_iq()` / `_uses_read()`.
 
 ### `esp_rtl_sdr_stream_config_t`
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -109,13 +109,15 @@ void example_wx(esp_rtl_sdr_handle_t sdr)
 
 ---
 
-## 5. Sync pull only (no event callback)
+## 5. Sync pull only (READ delivery mode)
 
 ```c
 void example_sync_read(void)
 {
     esp_rtl_sdr_config_t cfg;
-    esp_rtl_sdr_config_default(&cfg); /* event_cb = NULL */
+    esp_rtl_sdr_config_default(&cfg);
+    cfg.delivery_mode = ESP_RTL_SDR_DELIVERY_READ; /* no EVT_IQ_BLOCK; lazy pull ring */
+    /* event_cb may still receive STARTED / ERROR / HEALTH if set */
 
     esp_rtl_sdr_handle_t sdr = NULL;
     ESP_ERROR_CHECK(esp_rtl_sdr_install(&cfg, &sdr));

--- a/docs/HARDENING_0_7_2.md
+++ b/docs/HARDENING_0_7_2.md
@@ -25,8 +25,8 @@ This release pauses Phase 3 gain/bias **hardware** work for one hardening cut.
 | Item | Status |
 |---|---|
 | True async retune from callback (queue + owner drain) | **Done in 0.7.3** |
-| Delivery modes CALLBACK/READ/BOTH | Planned |
-| Lazy pull-ring (optional sync read) | Planned |
+| Delivery modes CALLBACK/READ/BOTH | **Done in 0.7.4** |
+| Lazy pull-ring (optional sync read) | **Done in 0.7.4** |
 | ESP-IDF P4 compile CI | **Done** in CI (`idf-p4-build`, IDF 5.3.2 + 5.4.1) |
 | Full atomics ownership model for all USB fields | Incremental |
 | Hardware soak from this tree | Lab |

--- a/docs/RUNTIME_CONSTANTS.md
+++ b/docs/RUNTIME_CONSTANTS.md
@@ -7,17 +7,25 @@ and how apps can influence them.
 
 ---
 
-## IQ pull ring
+## IQ delivery ring (USB → delivery task)
 
 | Constant | Value | Meaning |
 |---|---|---|
-| `kRingDepth` | **6** | Number of IQ slots in the internal free/filled queues for `read()` / delivery |
+| `kRingDepth` | **6** | Number of IQ slots in free/filled queues between bulk and delivery |
 
 **Why 6:** Matches multi-URB pipeline depth class of default `transfer_count` (6).
-Deep enough to absorb brief consumer jitter without unbounded RAM.
 
-**App control:** Not Kconfig yet. Tune **URB** geometry via config /
-[`KCONFIG.md`](KCONFIG.md) first; watch `consumer_drops`.
+## Sync-read pull ring (0.7.4 lazy)
+
+| Item | Behavior |
+|---|---|
+| When allocated | First IQ push or first `read()` if `delivery_mode` is BOTH or READ |
+| Never allocated | `DELIVERY_CALLBACK` |
+| Default size | ~4× URB total, min ~192 KiB, max 512 KiB |
+| Override | `config.pull_ring_bytes` (even, 1 KiB…1 MiB) |
+
+**App control:** Prefer `DELIVERY_CALLBACK` if you never call `read()` (saves RAM).
+Tune URB geometry via [`KCONFIG.md`](KCONFIG.md); watch `consumer_drops`.
 
 ---
 
@@ -61,6 +69,7 @@ Making delivery core configurable is **Planned** if products need it.
 |---|---|---|
 | `ESP_RTL_SDR_DEFAULT_XFER_BYTES` | 16384 | Also Kconfig |
 | `ESP_RTL_SDR_DEFAULT_XFER_COUNT` | 6 | Also Kconfig |
+| `config.delivery_mode` | BOTH | See API_REFERENCE delivery modes |
 | `ESP_RTL_SDR_DEFAULT_STOP_TIMEOUT_MS` | 3000 | `stop(…, 0)` |
 | `ESP_RTL_SDR_PASSPORT_DEFAULT_DWELL_MS` | 1500 | Passport |
 | Rate / freq windows | see header | [`RATES.md`](RATES.md) |

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,5 +1,5 @@
 ## esp_rtl_sdr — ESP Component Registry metadata
-version: "0.7.3"
+version: "0.7.4"
 description: >
   Clean-room ESP-IDF USB Host client for RTL2832U-class SDR dongles.
   Blog V4 (R828D) profile first; profile-based expansion for other tuners.

--- a/include/esp_rtl_sdr.h
+++ b/include/esp_rtl_sdr.h
@@ -85,7 +85,7 @@ extern "C" {
 /** Semantic version of this public header / binary API. */
 #define ESP_RTL_SDR_VERSION_MAJOR 0
 #define ESP_RTL_SDR_VERSION_MINOR 7
-#define ESP_RTL_SDR_VERSION_PATCH 3
+#define ESP_RTL_SDR_VERSION_PATCH 4
 
 #define ESP_RTL_SDR_VERSION_NUMBER                                      \
     ((ESP_RTL_SDR_VERSION_MAJOR * 10000) +                              \
@@ -286,7 +286,22 @@ typedef enum {
     ESP_RTL_SDR_CAP_HEALTH = 1u << 13,      /**< get_health / EVT_HEALTH */
     ESP_RTL_SDR_CAP_PASSPORT = 1u << 14,    /**< on-device rate passport probe */
     ESP_RTL_SDR_CAP_GAIN = 1u << 15,        /**< tuner gain APIs (off until measured) */
+    ESP_RTL_SDR_CAP_DELIVERY_MODE = 1u << 16, /**< config.delivery_mode honored */
 } esp_rtl_sdr_cap_t;
+
+/**
+ * How IQ samples reach the app (0.7.4+).
+ * Other events (STARTED, ERROR, RETUNED, HEALTH, …) still use event_cb when set.
+ *
+ * BOTH (default): EVT_IQ_BLOCK + blocking read() pull ring.
+ * CALLBACK: EVT_IQ_BLOCK only — no pull-ring RAM until mode changes.
+ * READ: pull ring only — no EVT_IQ_BLOCK (saves callback cost).
+ */
+typedef enum {
+    ESP_RTL_SDR_DELIVERY_BOTH = 0,
+    ESP_RTL_SDR_DELIVERY_CALLBACK = 1,
+    ESP_RTL_SDR_DELIVERY_READ = 2,
+} esp_rtl_sdr_delivery_mode_t;
 
 /**
  * Intent presets — apps describe the mission; driver picks LO/rate defaults.
@@ -462,6 +477,17 @@ typedef struct {
     uint8_t usb_task_priority;
     /** Core affinity: 0 or 1, or 0xFF = no affinity. */
     uint8_t usb_task_core_id;
+    /**
+     * IQ delivery path (append-only field — older struct_size keeps BOTH).
+     * See esp_rtl_sdr_delivery_mode_t. Default BOTH.
+     */
+    esp_rtl_sdr_delivery_mode_t delivery_mode;
+    /**
+     * Optional pull-ring capacity in bytes (CU8). 0 = auto
+     * (~4× URB total, min ~192 KiB, max 512 KiB). Only allocated when the
+     * mode uses read() (lazy on first push/read).
+     */
+    size_t pull_ring_bytes;
 } esp_rtl_sdr_config_t;
 
 typedef struct {
@@ -537,6 +563,12 @@ esp_err_t esp_rtl_sdr_preset_frequency_hz(esp_rtl_sdr_preset_t preset,
 
 /** Capability bitmask for this binary (see esp_rtl_sdr_cap_t). */
 uint32_t esp_rtl_sdr_get_capabilities(void);
+
+/** True if mode emits EVT_IQ_BLOCK for bulk IQ. */
+bool esp_rtl_sdr_delivery_mode_uses_callback_iq(esp_rtl_sdr_delivery_mode_t mode);
+
+/** True if mode fills the sync-read pull ring (esp_rtl_sdr_read). */
+bool esp_rtl_sdr_delivery_mode_uses_read(esp_rtl_sdr_delivery_mode_t mode);
 
 /* -------------------------------------------------------------------------- */
 /* Lifecycle                                                                  */
@@ -681,13 +713,16 @@ esp_err_t esp_rtl_sdr_get_sample_rate(esp_rtl_sdr_handle_t handle, uint32_t *out
 
 /**
  * Blocking pull of interleaved CU8 IQ bytes (sync-read equivalent).
- * Works while STREAMING whether or not an event callback is installed.
+ * Requires delivery_mode BOTH or READ (default BOTH). Returns
+ * ERR_UNSUPPORTED for CALLBACK-only mode.
+ * Works while STREAMING; pull ring is allocated lazily on first use when needed.
  * @param out_buf  Destination; must be non-NULL.
  * @param max_bytes  Capacity; should be even (odd truncated down).
  * @param timeout_ms  0 = return immediately with whatever is buffered.
  * @param out_bytes  Required; set to bytes copied (0 on timeout with empty buffer).
  * @return ESP_OK if any bytes copied, ERR_TIMEOUT if none within timeout while
- *         streaming, ERR_NOT_STREAMING if idle, other errors as usual.
+ *         streaming, ERR_NOT_STREAMING if idle, ERR_UNSUPPORTED if mode is
+ *         CALLBACK-only, other errors as usual.
  */
 esp_err_t esp_rtl_sdr_read(esp_rtl_sdr_handle_t handle, uint8_t *out_buf, size_t max_bytes,
                            uint32_t timeout_ms, size_t *out_bytes);

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "esp_rtl_sdr",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Clean-room ESP USB Host client for RTL2832U-class SDR (Blog V4 profile first)",
   "keywords": "sdr, rtl-sdr, rtl2832u, usb, esp32-p4, esp_rtl_sdr",
   "license": "AGPL-3.0-only",

--- a/src/esp_rtl_sdr.cpp
+++ b/src/esp_rtl_sdr.cpp
@@ -803,14 +803,18 @@ static esp_err_t ensure_pull_ring(esp_rtl_sdr_handle *h)
     if (h->pull_buf != nullptr && h->pull_cap > 0) {
         return ESP_OK;
     }
-    /* ~0.2 s at 960 kS/s CU8 (192 KiB), or 4× URB total, cap 512 KiB. */
-    size_t need = h->cfg.transfer_bytes * h->cfg.transfer_count * 4u;
-    if (need < 96000u * 2u) {
-        need = 96000u * 2u;
+    size_t need = h->cfg.pull_ring_bytes;
+    if (need == 0) {
+        /* ~0.2 s at 960 kS/s CU8 (192 KiB), or 4× URB total, cap 512 KiB. */
+        need = h->cfg.transfer_bytes * h->cfg.transfer_count * 4u;
+        if (need < 96000u * 2u) {
+            need = 96000u * 2u;
+        }
+        if (need > 512u * 1024u) {
+            need = 512u * 1024u;
+        }
     }
-    if (need > 512u * 1024u) {
-        need = 512u * 1024u;
-    }
+    need &= ~size_t{1};
     h->pull_buf = static_cast<uint8_t *>(
         heap_caps_malloc(need, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
     if (h->pull_buf == nullptr) {
@@ -865,11 +869,9 @@ static void delivery_task_fn(void *arg)
         block.sample_rate_sps = slot->sample_rate_sps;
         block.host_timestamp_us = slot->host_timestamp_us;
 
-        /* Always feed sync-read ring so read() works with or without event_cb. */
-        pull_ring_push(h, slot->data, slot->bytes);
-
         esp_rtl_sdr_event_cb_t cb = nullptr;
         void *ctx = nullptr;
+        esp_rtl_sdr_delivery_mode_t mode = ESP_RTL_SDR_DELIVERY_BOTH;
         bool emit_health = false;
         esp_rtl_sdr_health_info_t health{};
         {
@@ -877,6 +879,7 @@ static void delivery_task_fn(void *arg)
             if (lk.ok()) {
                 cb = h->cfg.event_cb;
                 ctx = h->cfg.event_ctx;
+                mode = h->cfg.delivery_mode;
                 h->health_emit_blocks++;
                 if (cb != nullptr && h->streaming) {
                     fill_health_info(h, &health);
@@ -890,8 +893,24 @@ static void delivery_task_fn(void *arg)
                 }
             }
         }
+
+        /* Lazy pull ring: allocate only when mode uses read() and IQ arrives. */
+        if (esp_rtl_sdr_delivery_mode_uses_read(mode)) {
+            if (ensure_pull_ring(h) == ESP_OK) {
+                pull_ring_push(h, slot->data, slot->bytes);
+            } else {
+                HandleLock lk(h, kQueryLockTicks);
+                if (lk.ok()) {
+                    h->metrics.consumer_drops +=
+                        static_cast<uint32_t>(slot->bytes > 0 ? slot->bytes : 1);
+                }
+            }
+        }
+
         if (cb != nullptr) {
-            emit_after_unlock(h, ESP_RTL_SDR_EVT_IQ_BLOCK, &block, cb, ctx);
+            if (esp_rtl_sdr_delivery_mode_uses_callback_iq(mode)) {
+                emit_after_unlock(h, ESP_RTL_SDR_EVT_IQ_BLOCK, &block, cb, ctx);
+            }
             if (emit_health) {
                 emit_after_unlock(h, ESP_RTL_SDR_EVT_HEALTH, &health, cb, ctx);
             }
@@ -1723,11 +1742,12 @@ esp_err_t esp_rtl_sdr_start(esp_rtl_sdr_handle_t handle,
         if (ret != ESP_OK) {
             break;
         }
-        ret = ensure_pull_ring(handle);
-        if (ret != ESP_OK) {
-            break;
+        /* Pull ring is lazy: allocated on first IQ push or first read() when mode
+         * uses READ/BOTH. CALLBACK-only never allocates the large pull buffer. */
+        if (esp_rtl_sdr_delivery_mode_uses_read(handle->cfg.delivery_mode) &&
+            handle->pull_buf != nullptr) {
+            pull_ring_reset(handle);
         }
-        pull_ring_reset(handle);
         ret = alloc_bulk_pool(handle, static_cast<uint32_t>(handle->cfg.transfer_count),
                               static_cast<uint32_t>(handle->cfg.transfer_bytes));
         if (ret != ESP_OK) {
@@ -2034,6 +2054,29 @@ esp_err_t esp_rtl_sdr_read(esp_rtl_sdr_handle_t handle, uint8_t *out_buf, size_t
         if (handle->state != ESP_RTL_SDR_STATE_STREAMING || !handle->streaming) {
             set_error_unlocked(handle, ESP_RTL_SDR_ERR_NOT_STREAMING);
             return ESP_RTL_SDR_ERR_NOT_STREAMING;
+        }
+        if (!esp_rtl_sdr_delivery_mode_uses_read(handle->cfg.delivery_mode)) {
+            set_error_unlocked(handle, ESP_RTL_SDR_ERR_UNSUPPORTED);
+            return ESP_RTL_SDR_ERR_UNSUPPORTED;
+        }
+    }
+
+    /* Lazy allocate pull ring on first read if IQ has not filled it yet. */
+    {
+        esp_err_t pr = ensure_pull_ring(handle);
+        if (pr != ESP_OK) {
+            HandleLock lk(handle, kQueryLockTicks);
+            if (lk.ok()) {
+                set_error_unlocked(handle, pr);
+            }
+            return pr;
+        }
+    }
+
+    {
+        HandleLock lk(handle, kQueryLockTicks);
+        if (!lk.ok()) {
+            return ESP_RTL_SDR_ERR_TIMEOUT;
         }
         if (handle->pull_buf == nullptr || handle->pull_mux == nullptr) {
             set_error_unlocked(handle, ESP_RTL_SDR_ERR_NOT_READY);

--- a/src/esp_rtl_sdr.cpp
+++ b/src/esp_rtl_sdr.cpp
@@ -798,11 +798,51 @@ static void pull_ring_reset(esp_rtl_sdr_handle *h)
     }
 }
 
+/** Tear down pull ring under handle lock (or during uninstall). Fail-closed. */
+static void destroy_pull_ring_unlocked(esp_rtl_sdr_handle *h)
+{
+    if (h == nullptr) {
+        return;
+    }
+    if (h->pull_buf != nullptr) {
+        free(h->pull_buf);
+        h->pull_buf = nullptr;
+    }
+    h->pull_cap = h->pull_r = h->pull_w = h->pull_count = 0;
+    if (h->pull_mux != nullptr) {
+        vSemaphoreDelete(h->pull_mux);
+        h->pull_mux = nullptr;
+    }
+    if (h->pull_sem != nullptr) {
+        vSemaphoreDelete(h->pull_sem);
+        h->pull_sem = nullptr;
+    }
+}
+
+/**
+ * Lazy pull-ring init. Serialized on the handle API lock so delivery_task and
+ * esp_rtl_sdr_read cannot race a double-alloc or leave a half-initialized ring.
+ */
 static esp_err_t ensure_pull_ring(esp_rtl_sdr_handle *h)
 {
-    if (h->pull_buf != nullptr && h->pull_cap > 0) {
+    if (h == nullptr) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    HandleLock lk(h);
+    if (!lk.ok()) {
+        return ESP_RTL_SDR_ERR_TIMEOUT;
+    }
+
+    if (h->pull_buf != nullptr && h->pull_cap > 0 && h->pull_mux != nullptr &&
+        h->pull_sem != nullptr) {
         return ESP_OK;
     }
+    /* Incomplete prior attempt must not satisfy a false success path. */
+    if (h->pull_buf != nullptr || h->pull_mux != nullptr || h->pull_sem != nullptr ||
+        h->pull_cap != 0) {
+        destroy_pull_ring_unlocked(h);
+    }
+
     size_t need = h->cfg.pull_ring_bytes;
     if (need == 0) {
         /* ~0.2 s at 960 kS/s CU8 (192 KiB), or 4× URB total, cap 512 KiB. */
@@ -815,26 +855,38 @@ static esp_err_t ensure_pull_ring(esp_rtl_sdr_handle *h)
         }
     }
     need &= ~size_t{1};
-    h->pull_buf = static_cast<uint8_t *>(
-        heap_caps_malloc(need, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
-    if (h->pull_buf == nullptr) {
-        h->pull_buf =
-            static_cast<uint8_t *>(heap_caps_malloc(need, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
+    if (need < 2u) {
+        return ESP_ERR_INVALID_ARG;
     }
-    if (h->pull_buf == nullptr) {
+
+    uint8_t *buf = static_cast<uint8_t *>(
+        heap_caps_malloc(need, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+    if (buf == nullptr) {
+        buf = static_cast<uint8_t *>(heap_caps_malloc(need, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
+    }
+    if (buf == nullptr) {
         return ESP_ERR_NO_MEM;
     }
+
+    SemaphoreHandle_t mux = xSemaphoreCreateMutex();
+    SemaphoreHandle_t sem = xSemaphoreCreateBinary();
+    if (mux == nullptr || sem == nullptr) {
+        if (mux != nullptr) {
+            vSemaphoreDelete(mux);
+        }
+        if (sem != nullptr) {
+            vSemaphoreDelete(sem);
+        }
+        free(buf);
+        return ESP_ERR_NO_MEM;
+    }
+
+    /* Publish fully-formed ring only after all pieces exist. */
+    h->pull_buf = buf;
     h->pull_cap = need;
     h->pull_r = h->pull_w = h->pull_count = 0;
-    if (h->pull_mux == nullptr) {
-        h->pull_mux = xSemaphoreCreateMutex();
-    }
-    if (h->pull_sem == nullptr) {
-        h->pull_sem = xSemaphoreCreateBinary();
-    }
-    if (h->pull_mux == nullptr || h->pull_sem == nullptr) {
-        return ESP_ERR_NO_MEM;
-    }
+    h->pull_mux = mux;
+    h->pull_sem = sem;
     return ESP_OK;
 }
 
@@ -1472,9 +1524,7 @@ esp_err_t esp_rtl_sdr_uninstall(esp_rtl_sdr_handle_t handle)
         handle->ctrl_xfer = nullptr;
     }
     destroy_iq_ring(handle);
-    free(handle->pull_buf);
-    handle->pull_buf = nullptr;
-    handle->pull_cap = handle->pull_count = handle->pull_r = handle->pull_w = 0;
+    destroy_pull_ring_unlocked(handle);
 
     HandleLock lk(handle, kUninstallLockTicks);
     handle->magic = 0;
@@ -1490,14 +1540,6 @@ esp_err_t esp_rtl_sdr_uninstall(esp_rtl_sdr_handle_t handle)
     }
     if (handle->bulk_done_sem) {
         vSemaphoreDelete(handle->bulk_done_sem);
-    }
-    if (handle->pull_mux) {
-        vSemaphoreDelete(handle->pull_mux);
-        handle->pull_mux = nullptr;
-    }
-    if (handle->pull_sem) {
-        vSemaphoreDelete(handle->pull_sem);
-        handle->pull_sem = nullptr;
     }
     if (lock) {
         (void)xSemaphoreTake(lock, 0);

--- a/src/esp_rtl_sdr_policy.cpp
+++ b/src/esp_rtl_sdr_policy.cpp
@@ -40,7 +40,18 @@ uint32_t esp_rtl_sdr_get_capabilities(void)
            ESP_RTL_SDR_CAP_CUSTOM_HZ | ESP_RTL_SDR_CAP_HOTPLUG |
            ESP_RTL_SDR_CAP_FREQ_CORRECTION | ESP_RTL_SDR_CAP_MULTI_DEVICE |
            ESP_RTL_SDR_CAP_SYNC_READ | ESP_RTL_SDR_CAP_CONTINUOUS_RATE |
-           ESP_RTL_SDR_CAP_NEED | ESP_RTL_SDR_CAP_HEALTH | ESP_RTL_SDR_CAP_PASSPORT;
+           ESP_RTL_SDR_CAP_NEED | ESP_RTL_SDR_CAP_HEALTH | ESP_RTL_SDR_CAP_PASSPORT |
+           ESP_RTL_SDR_CAP_DELIVERY_MODE;
+}
+
+bool esp_rtl_sdr_delivery_mode_uses_callback_iq(esp_rtl_sdr_delivery_mode_t mode)
+{
+    return mode == ESP_RTL_SDR_DELIVERY_BOTH || mode == ESP_RTL_SDR_DELIVERY_CALLBACK;
+}
+
+bool esp_rtl_sdr_delivery_mode_uses_read(esp_rtl_sdr_delivery_mode_t mode)
+{
+    return mode == ESP_RTL_SDR_DELIVERY_BOTH || mode == ESP_RTL_SDR_DELIVERY_READ;
 }
 
 const char *esp_rtl_sdr_state_to_name(esp_rtl_sdr_state_t state)
@@ -227,6 +238,8 @@ void esp_rtl_sdr_config_default(esp_rtl_sdr_config_t *config)
     config->control_timeout_ms = 1000;
     config->usb_task_priority = 0;
     config->usb_task_core_id = 0xFF;
+    config->delivery_mode = ESP_RTL_SDR_DELIVERY_BOTH;
+    config->pull_ring_bytes = 0;
 }
 
 void esp_rtl_sdr_stream_config_default(esp_rtl_sdr_stream_config_t *stream)
@@ -274,6 +287,16 @@ esp_err_t esp_rtl_sdr_config_validate(const esp_rtl_sdr_config_t *config)
     }
     if (local.usb_task_core_id != 0xFF && local.usb_task_core_id > 1) {
         return ESP_ERR_INVALID_ARG;
+    }
+    if (local.delivery_mode > ESP_RTL_SDR_DELIVERY_READ) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    /* pull_ring_bytes 0 = auto; else must be even and within a sane bound */
+    if (local.pull_ring_bytes != 0) {
+        if ((local.pull_ring_bytes % 2u) != 0 || local.pull_ring_bytes < 1024u ||
+            local.pull_ring_bytes > (1024u * 1024u)) {
+            return ESP_ERR_INVALID_ARG;
+        }
     }
     return ESP_OK;
 }

--- a/tests/host/test_policy.cpp
+++ b/tests/host/test_policy.cpp
@@ -94,7 +94,8 @@ static void test_capabilities(void)
                              ESP_RTL_SDR_CAP_HOTPLUG | ESP_RTL_SDR_CAP_FREQ_CORRECTION |
                              ESP_RTL_SDR_CAP_MULTI_DEVICE | ESP_RTL_SDR_CAP_SYNC_READ |
                              ESP_RTL_SDR_CAP_CONTINUOUS_RATE | ESP_RTL_SDR_CAP_NEED |
-                             ESP_RTL_SDR_CAP_HEALTH | ESP_RTL_SDR_CAP_PASSPORT;
+                             ESP_RTL_SDR_CAP_HEALTH | ESP_RTL_SDR_CAP_PASSPORT |
+                             ESP_RTL_SDR_CAP_DELIVERY_MODE;
     EXPECT_EQ_U(c & need_on, need_on);
 
     /* Phase 3 / reserved — must stay off until measured */
@@ -306,6 +307,35 @@ static void test_config_validate(void)
     cfg.usb_task_core_id = 0xFF;
     EXPECT_EQ_I(esp_rtl_sdr_config_validate(&cfg), ESP_OK);
 
+    esp_rtl_sdr_config_default(&cfg);
+    EXPECT_EQ_U((unsigned)cfg.delivery_mode, (unsigned)ESP_RTL_SDR_DELIVERY_BOTH);
+    EXPECT_EQ_U(cfg.pull_ring_bytes, 0);
+    cfg.delivery_mode = ESP_RTL_SDR_DELIVERY_CALLBACK;
+    EXPECT_EQ_I(esp_rtl_sdr_config_validate(&cfg), ESP_OK);
+    cfg.delivery_mode = ESP_RTL_SDR_DELIVERY_READ;
+    EXPECT_EQ_I(esp_rtl_sdr_config_validate(&cfg), ESP_OK);
+    cfg.delivery_mode = static_cast<esp_rtl_sdr_delivery_mode_t>(99);
+    EXPECT_EQ_I(esp_rtl_sdr_config_validate(&cfg), ESP_ERR_INVALID_ARG);
+
+    esp_rtl_sdr_config_default(&cfg);
+    cfg.pull_ring_bytes = 4096;
+    EXPECT_EQ_I(esp_rtl_sdr_config_validate(&cfg), ESP_OK);
+    cfg.pull_ring_bytes = 1001; /* odd */
+    EXPECT_EQ_I(esp_rtl_sdr_config_validate(&cfg), ESP_ERR_INVALID_ARG);
+    cfg.pull_ring_bytes = 512; /* too small */
+    EXPECT_EQ_I(esp_rtl_sdr_config_validate(&cfg), ESP_ERR_INVALID_ARG);
+
+    /* Old struct_size: trailing delivery fields default to BOTH / 0 */
+    esp_rtl_sdr_config_default(&cfg);
+    cfg.delivery_mode = ESP_RTL_SDR_DELIVERY_READ;
+    cfg.pull_ring_bytes = 8192;
+    {
+        esp_rtl_sdr_config_t old = cfg;
+        old.struct_size =
+            offsetof(esp_rtl_sdr_config_t, usb_task_core_id) + sizeof(uint8_t);
+        EXPECT_EQ_I(esp_rtl_sdr_config_validate(&old), ESP_OK);
+    }
+
     EXPECT_EQ_I(esp_rtl_sdr_config_validate(nullptr), ESP_ERR_INVALID_ARG);
     esp_rtl_sdr_config_default(nullptr); /* no crash */
 
@@ -382,6 +412,16 @@ static void test_passport_opts(void)
     esp_rtl_sdr_passport_opts_default(nullptr); /* no crash */
 }
 
+static void test_delivery_mode_helpers(void)
+{
+    EXPECT_TRUE(esp_rtl_sdr_delivery_mode_uses_callback_iq(ESP_RTL_SDR_DELIVERY_BOTH));
+    EXPECT_TRUE(esp_rtl_sdr_delivery_mode_uses_read(ESP_RTL_SDR_DELIVERY_BOTH));
+    EXPECT_TRUE(esp_rtl_sdr_delivery_mode_uses_callback_iq(ESP_RTL_SDR_DELIVERY_CALLBACK));
+    EXPECT_TRUE(!esp_rtl_sdr_delivery_mode_uses_read(ESP_RTL_SDR_DELIVERY_CALLBACK));
+    EXPECT_TRUE(!esp_rtl_sdr_delivery_mode_uses_callback_iq(ESP_RTL_SDR_DELIVERY_READ));
+    EXPECT_TRUE(esp_rtl_sdr_delivery_mode_uses_read(ESP_RTL_SDR_DELIVERY_READ));
+}
+
 static void test_usb_identity_constants(void)
 {
     EXPECT_EQ_U(ESP_RTL_SDR_USB_VID, 0x0BDAu);
@@ -408,6 +448,7 @@ int main(void)
     std::printf("esp_rtl_sdr host policy tests (%s)\n", esp_rtl_sdr_get_version_string());
     test_version();
     test_capabilities();
+    test_delivery_mode_helpers();
     test_rate_windows();
     test_recommended_rates();
     test_frequency();


### PR DESCRIPTION
## Summary

Implements the open hardening item **Delivery CALLBACK/READ/BOTH + lazy pull ring** (roadmap / HARDENING_0_7_2).

### Behavior
| Mode | EVT_IQ_BLOCK | `read()` | Pull-ring RAM |
|------|--------------|----------|---------------|
| **BOTH** (default) | yes | yes | lazy on first IQ/`read` |
| **CALLBACK** | yes | `ERR_UNSUPPORTED` | never |
| **READ** | no | yes | lazy on first IQ/`read` |

- Other events (STARTED, ERROR, RETUNED, HEALTH, …) still use `event_cb` when set.
- `config.pull_ring_bytes` optional (0 = auto size).
- Append-only ABI: older `struct_size` keeps BOTH + auto pull size.
- Version **0.7.4**, `CAP_DELIVERY_MODE`.

### Why
Apps that only use async IQ no longer pay ~192–512 KiB pull buffer by default when they choose CALLBACK. Sync-only apps can use READ without IQ callback noise.

### Test plan
- [x] Host policy tests updated (caps, delivery helpers, validate delivery_mode / pull_ring_bytes / ABI min size)
- [ ] CI: host-policy + truth-hygiene + idf-p4-build
- [ ] Lab optional: smoke with CALLBACK and READ modes

### Docs
API_REFERENCE, EXAMPLES, RUNTIME_CONSTANTS, CHANGELOG, PROJECT_TRUTH, Roadmap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable IQ delivery modes: callback, read, or both.
  - Added adjustable pull-ring capacity with lazy allocation for read-based delivery.
  - Added capability detection and delivery-mode helper APIs.
  - Added clearer handling for unsupported reads in callback-only mode.

- **Documentation**
  - Updated API references, examples, runtime guidance, roadmap, and release documentation for version 0.7.4.
  - Documented delivery-mode behavior, sizing limits, defaults, and compatibility details.

- **Testing**
  - Added coverage for delivery modes, pull-ring validation, capability reporting, and helper behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->