### PR TITLE
feat(0.7.8): measured Tuner AGC AUTO and RTL digital AGC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+## 0.7.8 (2026-08-26)
+
+### Added — measured Tuner AGC AUTO + RTL digital AGC
+
+- **`CAP_GAIN_AUTO`**: `set_tuner_gain_mode(AUTO)` writes measured R828D IR trio
+  `05=E8 07=78 0C=6B` (lab 2026-08-26). MANUAL restores the last ladder step.
+- **`CAP_RTL_AGC`**: additive `set/get_rtl_agc` — demod `0x19` ON=`0x25` OFF=`0x05`.
+  Not tuner AUTO. Apps that never call it are unchanged.
+- Same async bulk-pause sideband queue as mid-stream gain/bias (0.7.6).
+- Fail-closed: unclaimed → `ERR_NOT_CLAIMED`; callback → `ERR_REENTRANT`;
+  same mode twice is a no-op. `set_tuner_gain` still forces MANUAL.
+- After AUTO, skip triplexer filter rewrite (would clobber `0x0c=0x6B`).
+- **IF / SDR# Bandwidth:** capture was USB-silent after open. `CAP_IF_FILTER` not added.
+
+### Evidence
+
+- `agc_tuner_on_off.pcapng` SHA-256 `E131C5C6…3E8E` (4 ON/OFF clusters)
+- `agc_rtl_on_off.pcapng` SHA-256 `1E5B0061…D482` (4 demod 0x19 writes)
+- `if_filters_steps.pcapng` SHA-256 `D9D32608…A9FB` (software-only Bandwidth)
+- Procedure: `docs/AGC_IF_CAPTURE.md`
+
 ## 0.7.7 (2026-08-13)
 
 ### Added — Blog V4 HF upconverter CAP

--- a/PROJECT_TRUTH.md
+++ b/PROJECT_TRUTH.md
@@ -6,8 +6,8 @@ wins for *what is true right now*.
 Same discipline as [TheOrc PROJECT_TRUTH](https://github.com/hardcoreerik/TheOrc):
 claims need evidence labels; oversell is a bug; retract rather than spin.
 
-Snapshot date: **2026-08-13**  
-Version: **0.7.7** (HF upconverter CAP + async gain/bias — not production-ready)  
+Snapshot date: **2026-08-26**  
+Version: **0.7.8** (measured Tuner AUTO + RTL AGC — not production-ready)  
 Local repo: `F:\Ai\ESP_RTL_SDR\`  
 Remote: **https://github.com/hardcoreerik/esp-rtl-sdr**  
 Open-source honesty: [docs/AI_DEVELOPMENT_DISCLOSURE.md](docs/AI_DEVELOPMENT_DISCLOSURE.md) ·
@@ -79,7 +79,10 @@ Product vision: **`docs/VISION.md`**. Silicon / DS map: **`docs/SILICON.md`**.
 | Full USB/RF CI | **No** | Needs P4 + dongle (lab only) |
 | `apply_need()` intent presets | **Implemented** | FM/ADSB/WX/HF/MAX_STABLE/LISTEN |
 | `get_health()` / `EVT_HEALTH` | **Implemented** | Poll + delivery emit (change/periodic) |
-| Gain / bias public API | **Implemented (measured V4)** | CAP_GAIN + CAP_BIAS_TEE **on**; AUTO AGC still unsupported; P4 re-soak open |
+| Gain / bias public API | **Implemented (measured V4)** | CAP_GAIN + CAP_BIAS_TEE **on**; P4 re-soak open |
+| Tuner AGC AUTO | **Implemented (measured 2026-08-26)** | CAP_GAIN_AUTO; `set_tuner_gain_mode(AUTO)`; P4 re-soak open |
+| RTL digital AGC | **Implemented (measured 2026-08-26)** | CAP_RTL_AGC; additive `set_rtl_agc`; not tuner AUTO |
+| R828D IF / SDR# Bandwidth | **No USB** (2026-08-26 capture) | Software-only; no CAP_IF_FILTER |
 | set/get center freq, rate, ppm | **Implemented** | |
 | Sync `read()` | **Implemented** | |
 | Delivery modes BOTH/CALLBACK/READ + lazy pull ring | **Implemented** | 0.7.4; CAP_DELIVERY_MODE |
@@ -111,6 +114,8 @@ Product vision: **`docs/VISION.md`**. Silicon / DS map: **`docs/SILICON.md`**.
 | **0.7.4** | Delivery modes BOTH/CALLBACK/READ + lazy pull ring |
 | **0.7.5** | Measured Blog V4 gain ladder + bias-T SYS EP0; CAP_GAIN/BIAS on |
 | **0.7.6** | Async mid-stream gain/bias (bulk-pause queue); stall retries; desktop-gap map |
+| **0.7.7** | HF upconverter CAP (RF+28.8e6) |
+| **0.7.8** | Measured Tuner AUTO + RTL digital AGC; IF filter USB-silent |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Make an RTL-SDR Blog V4 a first-class peripheral on ESP32-P4** — continuous I/Q over USB Host, with a real embedded driver API.
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
-![Status](https://img.shields.io/badge/version-0.7.7-green)
+![Status](https://img.shields.io/badge/version-0.7.8-green)
 [![GitHub](https://img.shields.io/badge/github-esp--rtl--sdr-black)](https://github.com/hardcoreerik/esp-rtl-sdr)
 ![Target](https://img.shields.io/badge/ESP32--P4-HS_USB-green)
 
@@ -57,7 +57,7 @@ On a P4, the **host USB and RAM path is the hard part**. We lean into that:
 | “Supports every RTL” marketing | **Fail closed** on unknown sticks; one measured profile first |
 | App figures out “is RF dead?” | **Health** narrative (USB / app / RF clip / weak) |
 
-We are **not** chasing full librtlsdr feature parity (AGC / IF filter still open). We are chasing a driver that is **safe to live inside a real FreeRTOS product**.
+We are **not** chasing full librtlsdr feature parity (tuner IF filter still open). We are chasing a driver that is **safe to live inside a real FreeRTOS product**.
 
 ---
 
@@ -180,7 +180,10 @@ if (err == ESP_OK && n > 0) {
 uint32_t caps = esp_rtl_sdr_get_capabilities();
 if (caps & ESP_RTL_SDR_CAP_STREAM) { /* start/stop OK to attempt */ }
 if (caps & ESP_RTL_SDR_CAP_GAIN) {
-    /* 0.7.5+: manual gain after start; AUTO mode still unsupported */
+    /* 0.7.5+: manual gain after start */
+}
+if (caps & ESP_RTL_SDR_CAP_GAIN_AUTO) {
+    /* 0.7.8+: set_tuner_gain_mode(AUTO) — measured Tuner AGC */
 }
 ```
 
@@ -235,16 +238,17 @@ Design contract: [`docs/API.md`](docs/API.md) · header: [`include/esp_rtl_sdr.h
 | `refresh_device_list` · `get_device_count` · `get_device_at` | Candidates |
 | `select_device` · `select_device_serial` | Choose Blog V4 by index/serial |
 
-### Gain, bias & HF (0.7.5–0.7.7 Blog V4)
+### Gain, bias & HF (0.7.5–0.7.8 Blog V4)
 
 | API | Today |
 |---|---|
 | `set/get_tuner_gain` · `get_tuner_gains` | Manual ladder 0.0…49.6 dB (CAP_GAIN); need claimed stream |
-| `set_tuner_gain_mode(MANUAL)` | OK; **AUTO** still unsupported |
+| `set_tuner_gain_mode(MANUAL\|AUTO)` | MANUAL ladder; AUTO measured R828D AGC (`CAP_GAIN_AUTO`, 0.7.8+) |
+| `set/get_rtl_agc` | RTL2832 digital AGC (`CAP_RTL_AGC`); not tuner AUTO |
 | `set/get_bias_tee` | Measured SYS EP0 (CAP_BIAS_TEE); need claimed stream |
 | HF (0.7.7) | **500 kHz…1766 MHz**; RF&lt;28.8 MHz uses +28.8 MHz upconverter (`CAP_HF_UPCONVERTER`) |
 
-Evidence: [`docs/PHASE3_CAPTURE_REPORT.md`](docs/PHASE3_CAPTURE_REPORT.md). P4 RF soak of HF FE still open.
+Evidence: [`docs/PHASE3_CAPTURE_REPORT.md`](docs/PHASE3_CAPTURE_REPORT.md), [`docs/AGC_IF_CAPTURE.md`](docs/AGC_IF_CAPTURE.md). P4 RF soak of HF FE / AUTO still open.
 
 ### Typical rates (macros)
 
@@ -287,7 +291,7 @@ install → IDLE
 
 | Works | Not yet |
 |---|---|
-| Blog V4 stream + retune + metrics on P4 | Tuner AGC AUTO EP0 |
+| Blog V4 stream + retune + metrics on P4 | Tuner IF / SDR# Bandwidth EP0 (USB-silent) |
 | Continuous rates + passport API | “Any RTL2832U” |
 | Manual gain + bias CAP (0.7.5+) | Formal multi-hour soak artifact from *this* repo only |
 | HF upconverter CAP (0.7.7) | IF / channel filter EP0 |

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -115,7 +115,8 @@ External review @ v0.7.3. Map: `docs/REVIEW_GAPS_2026-08.md`.
 - [x] Never paste librtlsdr gain tables (clean-room `measured_gain_bias_v4.hpp`)
 - [ ] P4 re-soak: `set_tuner_gain` / `set_bias_tee` on ESP host path
 - [ ] Optional multimeter SMA DC for bias-T
-- [ ] AUTO AGC capture (still unsupported)
+- [x] AUTO AGC capture (Tuner AUTO + RTL AGC, 0.7.8)
+- [ ] P4 re-soak of AUTO / RTL AGC from this tree
 - [ ] Lab: Baofeng / Flipper for clip vs weak health correlation
 
 **Exit:** Gain and bias work on Blog V4 with recorded procedure (+ P4 soak).

--- a/docs/AGC_IF_CAPTURE.md
+++ b/docs/AGC_IF_CAPTURE.md
@@ -1,0 +1,158 @@
+# AGC + IF-filter USB capture (Blog V4)
+
+**Goal:** Independently observe Blog V4 USB control traffic for:
+
+1. **Tuner AGC** on/off (R828D auto gain) — unblocks `set_tuner_gain_mode(AUTO)`
+2. **RTL AGC** on/off (RTL2832 digital AGC) — separate path; capture so we do not mix it up
+3. **IF / channel filter / tuner bandwidth** at a **fixed** sample rate — unblocks `CAP_IF_FILTER` *if* USB actually changes
+
+**Not this session:** manual RF gain ladder (already measured 2026-08-12), bias-T, P4 streaming.
+
+Desktop software is **black-box stimulus only**. Do **not** paste librtlsdr source. Clean-room: [CLEAN_ROOM.md](CLEAN_ROOM.md).
+
+Same PC lab as Phase 3: `C:\Tools\esp-rtl-sdr-lab\`. Dongle plugs into **this PC**, not the ESP32-P4.
+
+---
+
+## What plugs where
+
+| Thing | Where |
+|---|---|
+| RTL-SDR **Blog V4** | USB port on **this Windows PC** |
+| ESP32-P4 / Tab5 / Waveshare | Unplug the dongle from it; leave it alone |
+| Antenna | On the Blog V4 (FM broadcast is enough) |
+
+---
+
+## Software to open (only these)
+
+| App | Path / how | Role |
+|---|---|---|
+| **PowerShell** | Windows Terminal / pwsh | `rtl_test`, later notes |
+| **Wireshark** | Start menu, or `C:\Program Files\Wireshark\Wireshark.exe` | USB sniffer |
+| **SDR# (AIRSPY SDR# Studio)** | `C:\Tools\esp-rtl-sdr-lab\bin\SDRSharp.exe` | Click AGC / filter |
+| **Zadig** | `C:\Tools\esp-rtl-sdr-lab\bin\zadig.exe` | **Only if** `rtl_test` cannot open the stick |
+
+Do **not** open OrcSDR, rtl_tcp, a second SDR#, or SDR++ at the same time. One program owns the dongle.
+
+---
+
+## Prep (do this first — no capture yet)
+
+1. Unplug the Blog V4 from the P4. Plug it into the **PC**.
+2. Close anything that might be using it.
+3. Open a **new** PowerShell:
+
+```powershell
+cd C:\Tools\esp-rtl-sdr-lab
+$env:Path = "C:\Tools\esp-rtl-sdr-lab\bin;C:\Program Files\Wireshark;" + $env:Path
+rtl_test -t
+tshark -D
+```
+
+4. **Good `rtl_test`:** you see **RTLSDRBlog / Blog V4**, USB `0bda:2838`, tuner **R828D**. Ctrl+C to stop.  
+   **Bad (`usb_open error`, nothing listed):** run Zadig as admin → Options → List All Devices → Bulk-In **Interface 0** (`0BDA 2838`) → WinUSB → retry `rtl_test -t`.
+5. **Good `tshark -D`:** lines named **USBPcap1**, **USBPcap2**, …  
+   If those names are missing, USBPcap is not loaded — reboot once, then try again.
+6. Do **not** start SDR# until Wireshark is capturing (see below).
+
+---
+
+## Wireshark: start capture
+
+1. Open **Wireshark**.
+2. On the start screen, hold **Ctrl** and click **USBPcap1**, **USBPcap2**, and **USBPcap3** (same trick as the gain session — we may not know which hub).
+3. Click the blue shark fin (**Start capturing**).
+4. Display filter (optional, after start): `usb`
+
+Keep capture **short**. Start → do the clicks → stop. A 2-minute FM sit makes a huge file of IQ bulk we do not need.
+
+---
+
+## Capture A — Tuner AGC (the important one)
+
+Save as: `C:\Tools\esp-rtl-sdr-lab\captures\agc_tuner_on_off.pcapng`
+
+1. Wireshark already capturing.
+2. Open **SDR#**. Source = RTL-SDR USB. Play (triangle).
+3. Tune **96.1 MHz** (KZEL, same as last time). Sample rate **2.4 MSPS**.
+4. On the **RTL-SDR controller** panel (source configure — **not** the audio/radio AGC):
+   - **RTL AGC** = **off**
+   - **Tuner AGC** = **off**
+   - **Bias-Tee** = **off**
+   - RF Gain = a mid manual value (e.g. ~30 dB) and **leave it**
+5. Wait 2 seconds.
+6. Check **Tuner AGC** **ON**. Wait 3 seconds.
+7. Uncheck **Tuner AGC** (back **OFF**). Wait 3 seconds.
+8. Repeat ON / wait / OFF / wait **one more time**.
+9. Stop Play. **Stop** Wireshark. File → Save As the name above.
+
+Write wall-clock times in `NOTES_agc.md` if you can (“Tuner AGC ON at ~0:12”).
+
+**Do not confuse:** SDR# also has an **audio** AGC in the radio panel (`agcEnabled` in config). Ignore it. We only care about **Tuner AGC** on the RTL-SDR source panel.
+
+---
+
+## Capture B — RTL AGC (cheap extra)
+
+Save as: `C:\Tools\esp-rtl-sdr-lab\captures\agc_rtl_on_off.pcapng`
+
+Same setup. **Tuner AGC stays OFF.** Toggle only **RTL AGC** off → on → off (twice). Stop and save.
+
+This is a different chip block. If we skip it, we might later mistake RTL digital AGC for tuner AGC.
+
+---
+
+## Capture C — Filter / IF bandwidth (may be silent — that is still data)
+
+Save as: `C:\Tools\esp-rtl-sdr-lab\captures\if_filter_steps.pcapng`
+
+1. New Wireshark capture (USBPcap1–3 again).
+2. SDR# playing: 96.1 MHz, **2.4 MSPS**, Tuner AGC **off**, RTL AGC **off**, Bias **off**, RF Gain **fixed**.
+3. Mode **WFM**.
+4. On the radio panel, change **Filter** (or bandwidth) slowly, pausing ~2 s each:
+
+   `80 kHz → 100 → 120 → 150 → 180 → 200 → 220 kHz`
+
+   (Use whatever steps SDR# actually shows. Pause between them.)
+5. **Do not** change sample rate in this capture. Rate already has its own EP0.
+6. Stop Play. Stop Wireshark. Save as above.
+
+**Honesty:** SDR# “Filter” is often **software after IQ**. USB may not change. That means `CAP_IF_FILTER` stays **off** until we find a control that really hits the R828D. Capture anyway.
+
+Optional if Filter produced no obvious vendor traffic (we will check): one extra run in **SDR++** (`C:\Tools\esp-rtl-sdr-lab\bin\sdrpp.exe`) looking for a **Tuner Bandwidth** control, same fixed rate. Save `if_filter_sdrpp.pcapng`.
+
+---
+
+## After you save
+
+Tell the session:
+
+- File names + that they exist
+- Whether Tuner AGC / RTL AGC / Filter actually moved in the UI
+- `rtl_test` identity if you still have the window
+
+Then we hash the files, extract vendor EP0 (`bmRequestType 0x40`) like Phase 3, and only then implement AUTO / IF.
+
+---
+
+## Do not
+
+- Leave capture running while you listen to the radio
+- Toggle RF Gain in these files (contaminates AGC)
+- Copy registers from GitHub
+- Claim AUTO works because desktop does
+
+---
+
+## Lab result (2026-08-26)
+
+Dongle: Blog V4 `0bda:2838` SN 00000001. SDR#: 96.1 MHz, 2.4 MSPS, RF Gain 29.7 dB parked.
+
+| File | SHA-256 | Result |
+|---|---|---|
+| `agc_tuner_on_off.pcapng` | `E131C5C642E7DFE8443D4667975871C220FFF4A237826B8423E9E38944BD3E8E` | 4 clusters: AUTO ON `05=E8 07=78 0C=6B` |
+| `agc_rtl_on_off.pcapng` | `1E5B006179C548E62617F530D5BC292AD45900763F6BCEF357264D4FDD55D482` | 4 writes: demod `0x19` ON=`0x25` OFF=`0x05` |
+| `if_filters_steps.pcapng` | `D9D32608418D40A48E88C925E804C7D1B35AA782A604EEC02CC90C60AA27A9FB` | **No vendor OUT after open** |
+
+Shipped in **0.7.8** as `CAP_GAIN_AUTO` + `CAP_RTL_AGC`. No `CAP_IF_FILTER`.

--- a/docs/AI_DEVELOPMENT_DISCLOSURE.md
+++ b/docs/AI_DEVELOPMENT_DISCLOSURE.md
@@ -89,7 +89,7 @@ continuous rates, need/health/passport) done here.
 | EP0 / profile tables came from clean-room measurement, not librtlsdr source | Claimed; clean-room rules apply |
 | Same tables worked unmodified on a second P4 board (Waveshare) under OrcSDR | **Provenance** (OrcSDR), not yet re-logged from this tree’s example |
 | `probe_rates` / continuous rates validated on P4 from *this* tree | **Implemented**; hardware log still open |
-| Gain / bias-T | **0.7.5 measured** CAP_GAIN/BIAS on; AUTO + P4 re-soak open |
+| Gain / bias-T | **0.7.5 measured** CAP_GAIN/BIAS on; AUTO **0.7.8**; P4 re-soak open |
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,7 +1,7 @@
 # esp_rtl_sdr public API — design contract
 
 **Header:** [`include/esp_rtl_sdr.h`](../include/esp_rtl_sdr.h)  
-**Version:** 0.7.7  
+**Version:** 0.7.8  
 **Full parameter / return / example reference:** [`API_REFERENCE.md`](API_REFERENCE.md)
 
 This document is the **design contract** (invariants, threading, ABI growth).  
@@ -118,7 +118,7 @@ Prefer component codes over generic `INVALID_STATE` when the app can branch:
 
 ---
 
-## Capabilities (0.7.7 binary)
+## Capabilities (0.7.8 binary)
 
 | Flag | Status |
 |---|---|
@@ -135,7 +135,10 @@ Prefer component codes over generic `INVALID_STATE` when the app can branch:
 | `HEALTH` | On; `get_health` |
 | `PASSPORT` | On; `probe_rates` |
 | `DELIVERY_MODE` | On; `config.delivery_mode` BOTH/CALLBACK/READ |
-| `GAIN` | On (measured Blog V4 manual ladder; AUTO unsupported) |
+| `GAIN` | On (measured Blog V4 manual ladder) |
+| `GAIN_AUTO` | On (measured Tuner AGC AUTO, 0.7.8) |
+| `RTL_AGC` | On (measured demod 0x19, 0.7.8; additive) |
+| `HF_UPCONVERTER` | On (0.7.7) |
 | `BIAS_TEE` | On (measured SYS sequence; no multimeter DC yet) |
 | `IQ_ACQUIRE` | Off |
 | `DIRECT_SAMPLING` | Reserved off |

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # esp_rtl_sdr — API Reference
 
-> **Version tracked:** `0.7.7` (see `ESP_RTL_SDR_VERSION_*` in [`include/esp_rtl_sdr.h`](../include/esp_rtl_sdr.h))  
+> **Version tracked:** `0.7.8` (see `ESP_RTL_SDR_VERSION_*` in [`include/esp_rtl_sdr.h`](../include/esp_rtl_sdr.h))  
 > **Header of record:** [`include/esp_rtl_sdr.h`](../include/esp_rtl_sdr.h)  
 > **Design contract (invariants, ABI growth):** [`API.md`](API.md)  
 > **What works on hardware right now:** [`../PROJECT_TRUTH.md`](../PROJECT_TRUTH.md) wins on any claim conflict.
@@ -259,7 +259,7 @@ Any in-window rate is quantized to an exact RTL2832 ratio (`quantize_sample_rate
 | `ESP_RTL_SDR_ERR_TIMEOUT` | Control or stop / read timed out | Retry or increase timeout |
 | `ESP_RTL_SDR_ERR_FAULT` | Handle in FAULT | `reset` or `uninstall` |
 | `ESP_RTL_SDR_ERR_NOT_READY` | Client not ready yet | Brief wait / retry |
-| `ESP_RTL_SDR_ERR_UNSUPPORTED` | AUTO gain mode, wrong delivery mode, or path not built | Check capabilities / mode |
+| `ESP_RTL_SDR_ERR_UNSUPPORTED` | Wrong delivery mode, or path not built | Check capabilities / mode |
 | `ESP_RTL_SDR_ERR_STALE_HANDLE` | Use after uninstall | Clear pointer |
 | `ESP_RTL_SDR_ERR_REENTRANT` | Forbidden API from event callback | Defer to app task |
 | `ESP_RTL_SDR_ERR_NOT_CLAIMED` | Present but not claimed | Start / claim path |
@@ -296,7 +296,7 @@ uint32_t esp_rtl_sdr_get_capabilities(void);
 | **Returns** | Bitmask of `esp_rtl_sdr_cap_t` for **this binary** |
 | **Notes** | No handle required. CAP bits track **implemented** paths only. |
 
-### Capability map (0.7.7)
+### Capability map (0.7.8)
 
 | Flag | Bit | Status | Meaning |
 |---|---|---|---|
@@ -317,6 +317,9 @@ uint32_t esp_rtl_sdr_get_capabilities(void);
 | `ESP_RTL_SDR_CAP_PASSPORT` | 14 | **On** | `probe_rates` |
 | `ESP_RTL_SDR_CAP_GAIN` | 15 | **On** | Measured Blog V4 manual ladder (0.0…49.6 dB) |
 | `ESP_RTL_SDR_CAP_DELIVERY_MODE` | 16 | **On** | `config.delivery_mode` |
+| `ESP_RTL_SDR_CAP_HF_UPCONVERTER` | 17 | **On** | RF&lt;28.8 MHz → tuner LO+28.8e6 |
+| `ESP_RTL_SDR_CAP_GAIN_AUTO` | 18 | **On** | Tuner AGC AUTO (measured 05/07/0c) |
+| `ESP_RTL_SDR_CAP_RTL_AGC` | 19 | **On** | RTL2832 digital AGC (demod 0x19) |
 
 ```c
 const uint32_t need = ESP_RTL_SDR_CAP_STREAM | ESP_RTL_SDR_CAP_SYNC_READ;
@@ -1216,19 +1219,23 @@ P4 re-soak and multimeter DC are still lab-open — see [`PHASE3_CAPTURE_REPORT.
 
 | Function | Behavior |
 |---|---|
-| `set_tuner_gain_mode(MANUAL)` | OK (selects manual path) |
-| `set_tuner_gain_mode(AUTO)` | `ERR_UNSUPPORTED` — AGC EP0 not in capture set |
+| `set_tuner_gain_mode(MANUAL)` | Restore last ladder step (or 0.0 dB); no-op if already MANUAL |
+| `set_tuner_gain_mode(AUTO)` | **0.7.8+** measured IR `05=E8 07=78 0C=6B` (`CAP_GAIN_AUTO`) |
 | `get_tuner_gain_mode` | Last mode |
-| `set_tuner_gain` | Nearest measured step (tenths dB); writes IR `{0x05,0x07,0x0c}` |
+| `set_tuner_gain` | Nearest measured step; forces MANUAL; cancels queued AUTO |
 | `get_tuner_gain` | Last applied step (0 if never set) |
 | `get_tuner_gains` | 28 steps: 0…496 tenths dB (0.0…49.6 dB) |
 | `set_bias_tee` | SYS sequence `3004/3003/3001/3000` (ON: 3001=0x19, OFF: 0x18) |
 | `get_bias_tee` | Last requested preference |
+| `set/get_rtl_agc` | **0.7.8+** demod `0x19` ON=`0x25` OFF=`0x05` (`CAP_RTL_AGC`) |
 
 ```c
 if (esp_rtl_sdr_get_capabilities() & ESP_RTL_SDR_CAP_GAIN) {
     ESP_ERROR_CHECK(esp_rtl_sdr_set_tuner_gain_mode(sdr, ESP_RTL_SDR_GAIN_MODE_MANUAL));
     ESP_ERROR_CHECK(esp_rtl_sdr_set_tuner_gain(sdr, 400)); /* ~40.2 dB nearest */
+}
+if (esp_rtl_sdr_get_capabilities() & ESP_RTL_SDR_CAP_GAIN_AUTO) {
+    ESP_ERROR_CHECK(esp_rtl_sdr_set_tuner_gain_mode(sdr, ESP_RTL_SDR_GAIN_MODE_AUTO));
 }
 if (esp_rtl_sdr_get_capabilities() & ESP_RTL_SDR_CAP_BIAS_TEE) {
     ESP_ERROR_CHECK(esp_rtl_sdr_set_bias_tee(sdr, true));

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -2,7 +2,7 @@
 
 Desktop reference: **librtlsdr / rtl-sdr-blog**. Status matches `PROJECT_TRUTH.md`.
 
-| # | Desktop capability | librtlsdr (typical) | esp_rtl_sdr 0.7.7 | Phase |
+| # | Desktop capability | librtlsdr (typical) | esp_rtl_sdr 0.7.8 | Phase |
 |---|---|---|---|---|
 | 1 | Open / close | `rtlsdr_open` | `install` / `uninstall` | **Done** |
 | 2 | Async IQ | `read_async` | `start` + `EVT_IQ_BLOCK` | **Done** |
@@ -10,7 +10,7 @@ Desktop reference: **librtlsdr / rtl-sdr-blog**. Status matches `PROJECT_TRUTH.m
 | 4–5 | Center freq | set/get | set/get + retune | **Done** |
 | 6 | Sample rate | many rates | continuous in HW windows + quantize | **Done** (0.7) |
 | 7 | Get sample rate | yes | exact programmed SPS | **Done** |
-| 8–9 | Tuner gain | modes / steps | Manual ladder 0.0…49.6 dB (CAP_GAIN); AUTO open | **3 partial** |
+| 8–9 | Tuner gain | modes / steps | Manual ladder + Tuner AUTO (`CAP_GAIN_AUTO`) + RTL AGC | **Done (0.7.8)** |
 | 11 | ppm | yes | software LO offset | **Done** |
 | 12 | Bias-T | common | Measured SYS EP0 (CAP_BIAS_TEE); DC re-soak open | **3 partial** |
 | 13 | Direct sampling / HF | forks | **HF upconverter CAP** (RF+28.8e6); not direct sampling | **Done (0.7.7)** |

--- a/docs/DRIVER_GAPS_VS_DESKTOP.md
+++ b/docs/DRIVER_GAPS_VS_DESKTOP.md
@@ -19,7 +19,7 @@ Labels:
 | Desktop control | SDR# / rtlsdr | esp_rtl_sdr today | Gap owner |
 |---|---|---|---|
 | Manual tuner gain ladder | Full list | **Measured 28-step** Blog V4 (0.7.5+) | — done (measured) |
-| Tuner AGC (auto) | Yes | **UNSUPPORTED** | **Driver** — need AGC EP0 capture |
+| Tuner AGC (auto) | Yes | **Measured AUTO** (`CAP_GAIN_AUTO`, 0.7.8) | P4 re-soak |
 | IF / channel filter (tuner) | Often via gain stages + IF filter | **No** — only software LPF after IQ | **Driver/HW** — R828D IF/filter regs not measured as CAP |
 | Bias-T | Yes | **Measured SYS EP0** | Optional multimeter DC claim still open |
 | Direct sampling / HF | Forks | **HF upconverter CAP 0.7.7** (not direct sampling) | — soak RF |
@@ -32,7 +32,7 @@ Labels:
 ### Driver follow-ups exposed by FM work
 
 1. **Hardware channel filter** — SDR# “Filter” on WFM is partly **post-IQ DSP** (we mirrored that in `fm_pcm`) and partly **tuner IF bandwidth**. We never measured R828D IF-filter EP0 for Blog V4; software IF is the only honest CAP today.
-2. **AUTO gain** — CAP_GAIN is manual only; `set_tuner_gain_mode(AUTO)` fails closed.
+2. **AUTO gain** — **0.7.8 measured.** `CAP_GAIN_AUTO`; RTL digital AGC is separate (`CAP_RTL_AGC`).
 3. **Gain under bias / mid-stream** — improved by async bulk-pause EP0 (0.7.6); still not multimeter-certified bias DC.
 4. **No stereo / RDS path in driver** — pure app/DSP (or future IQ streaming for host demod).
 5. **HF / shortwave upconverter CAP** — **0.7.7 on**: RF &lt; 28.8 MHz maps to tuner LO
@@ -70,8 +70,8 @@ Labels:
 
 ### Driver (esp_rtl_sdr)
 
-1. **AUTO AGC EP0** — clean-room capture + CAP path  
-2. **Optional IF-filter / bandwidth EP0** for R828D if measured (do not invent)  
+1. ~~AUTO AGC EP0~~ **0.7.8 measured** (Tuner AUTO + RTL AGC). P4 re-soak.  
+2. **Optional IF-filter / bandwidth EP0** — 2026-08-26 SDR# Bandwidth was USB-silent; do not invent  
 3. **Hardening** gain+bias under load (retries exist; P4 soak log)  
 4. **Bias DC evidence** when multimeter available  
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -228,9 +228,13 @@ void example_gain_if_ready(esp_rtl_sdr_handle_t sdr)
         ESP_LOGW("ex", "CAP_GAIN unexpected off on 0.7.5+");
         return;
     }
-    /* Requires claimed interface (after start). AUTO mode still unsupported. */
+    /* Requires claimed interface (after start). */
     ESP_ERROR_CHECK(esp_rtl_sdr_set_tuner_gain_mode(sdr, ESP_RTL_SDR_GAIN_MODE_MANUAL));
     ESP_ERROR_CHECK(esp_rtl_sdr_set_tuner_gain(sdr, 400)); /* nearest ~40.2 dB */
+    if (esp_rtl_sdr_get_capabilities() & ESP_RTL_SDR_CAP_GAIN_AUTO) {
+        /* optional: Tuner AGC — measured 2026-08-26 */
+        /* ESP_ERROR_CHECK(esp_rtl_sdr_set_tuner_gain_mode(sdr, ESP_RTL_SDR_GAIN_MODE_AUTO)); */
+    }
     if (esp_rtl_sdr_get_capabilities() & ESP_RTL_SDR_CAP_BIAS_TEE) {
         ESP_ERROR_CHECK(esp_rtl_sdr_set_bias_tee(sdr, false));
     }

--- a/docs/GAIN_BIAS_CAPTURE.md
+++ b/docs/GAIN_BIAS_CAPTURE.md
@@ -2,7 +2,7 @@
 
 > **Status (0.7.5+):** CAP_GAIN and CAP_BIAS_TEE are **on** for Blog V4 manual gain
 > and bias-T, from clean-room USBPcap tables in `private/measured_gain_bias_v4.hpp`.
-> AUTO AGC remains unsupported. P4 re-soak of the ESP path is still open.
+> Tuner AUTO + RTL AGC: **0.7.8 measured** (`docs/AGC_IF_CAPTURE.md`). P4 re-soak of the ESP path is still open.
 > This document is the **capture procedure** for new profiles / re-measurement.
 > Do **not** paste librtlsdr / rtl-sdr-blog tables.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ When docs disagree, PROJECT_TRUTH wins.
 | [HARDENING_0_7_2.md](HARDENING_0_7_2.md) | 0.7.2 runtime hardening notes |
 | [DEVELOPMENT_NARRATIVE_0_7.md](DEVELOPMENT_NARRATIVE_0_7.md) | Verbose 0.7.x development commentary |
 | [GAIN_BIAS_CAPTURE.md](GAIN_BIAS_CAPTURE.md) | Phase 3 clean-room capture procedure |
+| [AGC_IF_CAPTURE.md](AGC_IF_CAPTURE.md) | Tuner AUTO / RTL AGC / IF-filter USB capture |
 | [PHASE3_PC_SETUP.md](PHASE3_PC_SETUP.md) | Windows PC tool install / PATH / session recipe |
 | [HANDOFF_PHASE3_GAIN_BIAS.md](HANDOFF_PHASE3_GAIN_BIAS.md) | Full handoff + plan to finish issue #1 (gain/bias CAP) |
 | [PHASE3_CAPTURE_REPORT.md](PHASE3_CAPTURE_REPORT.md) | Plain-English report: bias+gain lab captures and why they matter |

--- a/docs/REVIEW_GAPS_2026-08.md
+++ b/docs/REVIEW_GAPS_2026-08.md
@@ -6,7 +6,7 @@ and cannot be truthfully closed with docs alone.
 
 | # | Review finding | Status after this work | Evidence |
 |---|---|---|---|
-| 1 | Gain / bias incomplete | **0.7.5 tables + CAP on**; P4 re-soak / multimeter / AUTO still open | [`PHASE3_CAPTURE_REPORT.md`](PHASE3_CAPTURE_REPORT.md), [#1](https://github.com/hardcoreerik/esp-rtl-sdr/issues/1) |
+| 1 | Gain / bias incomplete | **0.7.5 tables + CAP on**; AUTO **0.7.8**; P4 re-soak / multimeter still open | [`PHASE3_CAPTURE_REPORT.md`](PHASE3_CAPTURE_REPORT.md), [`AGC_IF_CAPTURE.md`](AGC_IF_CAPTURE.md) |
 | 2 | Narrow HW (P4 + V4 only) | **Documented as intentional scope** | [`SCOPE.md`](SCOPE.md), [#4](https://github.com/hardcoreerik/esp-rtl-sdr/issues/4) Deferred |
 | 3 | Single maintainer + AI | **Disclosed** (not “fixed” — truth) | AI disclosure, CONTRIBUTING, [#5](https://github.com/hardcoreerik/esp-rtl-sdr/issues/5) |
 | 4 | Empty issues/PRs | **Seeded tracking issues** | [#1](https://github.com/hardcoreerik/esp-rtl-sdr/issues/1)–[#5](https://github.com/hardcoreerik/esp-rtl-sdr/issues/5) |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -70,7 +70,8 @@ Truth of claims: [`../PROJECT_TRUTH.md`](../PROJECT_TRUTH.md).
 | Symptom | Check |
 |---|---|
 | `ERR_NOT_CLAIMED` | Call after successful `start` (interface must be claimed) |
-| `ERR_UNSUPPORTED` on `set_tuner_gain_mode(AUTO)` | Expected — AUTO AGC EP0 not captured |
+| `ERR_NOT_CLAIMED` on `set_tuner_gain_mode` / `set_rtl_agc` | Call after `start` (interface claimed) |
+| `ERR_REENTRANT` on gain/AGC | Do not call from the IQ event callback |
 | Gain/bias no RF/DC effect on P4 | P4 re-soak still open; PC capture tables may need re-verify on host |
 | Multimeter shows 0 V with bias ON | SMA DC not lab-certified yet; confirm EP0 path + supply |
 

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,5 +1,5 @@
 ## esp_rtl_sdr — ESP Component Registry metadata
-version: "0.7.7"
+version: "0.7.8"
 description: >
   Clean-room ESP-IDF USB Host client for RTL2832U-class SDR dongles.
   Blog V4 (R828D) profile first; profile-based expansion for other tuners.

--- a/include/esp_rtl_sdr.h
+++ b/include/esp_rtl_sdr.h
@@ -85,7 +85,7 @@ extern "C" {
 /** Semantic version of this public header / binary API. */
 #define ESP_RTL_SDR_VERSION_MAJOR 0
 #define ESP_RTL_SDR_VERSION_MINOR 7
-#define ESP_RTL_SDR_VERSION_PATCH 7
+#define ESP_RTL_SDR_VERSION_PATCH 8
 
 #define ESP_RTL_SDR_VERSION_NUMBER                                      \
     ((ESP_RTL_SDR_VERSION_MAJOR * 10000) +                              \
@@ -298,6 +298,10 @@ typedef enum {
     ESP_RTL_SDR_CAP_DELIVERY_MODE = 1u << 16, /**< config.delivery_mode honored */
     /** Blog V4 HF path: RF&lt;28.8 MHz → tuner LO RF+28.8e6 + triplexer HF input (0.7.7+). */
     ESP_RTL_SDR_CAP_HF_UPCONVERTER = 1u << 17,
+    /** Tuner AGC AUTO EP0 (R828D 05/07/0c) — measured 2026-08-26. */
+    ESP_RTL_SDR_CAP_GAIN_AUTO = 1u << 18,
+    /** RTL2832 digital AGC (demod 0x19) — measured 2026-08-26; not tuner AUTO. */
+    ESP_RTL_SDR_CAP_RTL_AGC = 1u << 19,
 } esp_rtl_sdr_cap_t;
 
 /**
@@ -841,8 +845,9 @@ esp_err_t esp_rtl_sdr_get_rate_passport(esp_rtl_sdr_handle_t handle,
 /* -------------------------------------------------------------------------- */
 
 /**
- * Tuner gain mode. MANUAL is supported (CAP_GAIN). AUTO returns ERR_UNSUPPORTED
- * until AGC EP0 is captured (see docs/GAIN_BIAS_CAPTURE.md).
+ * Tuner gain mode. MANUAL = measured ladder (CAP_GAIN). AUTO = measured
+ * R828D AGC trio (CAP_GAIN_AUTO, 0.7.8+). Default get() is AUTO until the
+ * app forces MANUAL; AUTO EP0 is applied only after the interface is claimed.
  */
 typedef enum {
     ESP_RTL_SDR_GAIN_MODE_AUTO = 0,
@@ -850,8 +855,10 @@ typedef enum {
 } esp_rtl_sdr_gain_mode_t;
 
 /**
- * Set tuner gain mode. MANUAL is supported (measured Blog V4). AUTO returns
- * ERR_UNSUPPORTED until AGC EP0 is captured. Requires CAP_GAIN.
+ * Set tuner gain mode. Requires claimed interface (after start).
+ * AUTO writes measured 05/07/0c AGC ON (CAP_GAIN_AUTO). MANUAL restores the
+ * last ladder step (or 0.0 dB if never set). Same mode twice is a no-op.
+ * set_tuner_gain() forces MANUAL. Not the RTL digital AGC (see set_rtl_agc).
  */
 esp_err_t esp_rtl_sdr_set_tuner_gain_mode(esp_rtl_sdr_handle_t handle,
                                           esp_rtl_sdr_gain_mode_t mode);
@@ -882,6 +889,14 @@ esp_err_t esp_rtl_sdr_get_tuner_gains(esp_rtl_sdr_handle_t handle, int *out_gain
  */
 esp_err_t esp_rtl_sdr_set_bias_tee(esp_rtl_sdr_handle_t handle, bool enable);
 esp_err_t esp_rtl_sdr_get_bias_tee(esp_rtl_sdr_handle_t handle, bool *out_enable);
+
+/**
+ * RTL2832 digital AGC (SDR# "RTL AGC") — measured demod 0x19 ON=0x25 OFF=0x05.
+ * Requires CAP_RTL_AGC and a claimed interface. Independent of tuner AUTO.
+ * Additive 0.7.8; default off. Same reentrancy / async sideband rules as gain.
+ */
+esp_err_t esp_rtl_sdr_set_rtl_agc(esp_rtl_sdr_handle_t handle, bool enable);
+esp_err_t esp_rtl_sdr_get_rtl_agc(esp_rtl_sdr_handle_t handle, bool *out_enable);
 
 #ifdef __cplusplus
 }

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "esp_rtl_sdr",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Clean-room ESP USB Host client for RTL2832U-class SDR (Blog V4 profile first)",
   "keywords": "sdr, rtl-sdr, rtl2832u, usb, esp32-p4, esp_rtl_sdr",
   "license": "AGPL-3.0-only",

--- a/private/measured_gain_bias_v4.hpp
+++ b/private/measured_gain_bias_v4.hpp
@@ -73,6 +73,31 @@ constexpr size_t kMeasuredV4GainStepCount =
 constexpr uint8_t kMeasuredV4GainReg0c = 0x68;
 
 /**
+ * Tuner AGC AUTO — measured 2026-08-26 (agc_tuner_on_off.pcapng).
+ * Four post-open clusters, ON/OFF/ON/OFF. AUTO ON is a distinct 05/07/0c trio.
+ * SHA-256 E131C5C642E7DFE8443D4667975871C220FFF4A237826B8423E9E38944BD3E8E
+ *
+ * Manual 29.7 dB ladder is 05=F7 07=67 0C=68. AUTO is the first time 0x0c=0x6B
+ * appeared on this IR path (manual ladder never changed 0x0c).
+ */
+constexpr uint8_t kMeasuredV4TunerAgcReg05 = 0xe8;
+constexpr uint8_t kMeasuredV4TunerAgcReg07 = 0x78;
+constexpr uint8_t kMeasuredV4TunerAgcReg0c = 0x6b;
+
+/**
+ * RTL2832 digital AGC (SDR# "RTL AGC") — measured 2026-08-26
+ * (agc_rtl_on_off.pcapng).
+ * SHA-256 1E5B006179C548E62617F530D5BC292AD45900763F6BCEF357264D4FDD55D482
+ * Demod page write: wValue=0x1920 (reg 0x19 | 0x20), wIndex=0x0010 (OUT).
+ * Not the R828D tuner. Do not conflate with Tuner AGC AUTO.
+ */
+constexpr uint8_t kMeasuredV4RtlAgcReg = 0x19;
+constexpr uint16_t kMeasuredV4RtlAgcWvalue = 0x1920;
+constexpr uint16_t kMeasuredV4RtlAgcWindex = 0x0010;
+constexpr uint8_t kMeasuredV4RtlAgcOn = 0x25;
+constexpr uint8_t kMeasuredV4RtlAgcOff = 0x05;
+
+/**
  * Bias-T SYS sequence measured from rtl_biast clusters (toggle groups).
  * ON:  3001 data 0x19   OFF: 3001 data 0x18  (LSB differs)
  * Companion writes 3004/3003/3000 match every observed toggle cluster.
@@ -106,6 +131,18 @@ inline RtlControlRecord measured_v4_ir_reg_write(uint8_t reg, uint8_t value)
     rec.length = 2;
     rec.data[0] = reg;
     rec.data[1] = value;
+    return rec;
+}
+
+/** Measured demod vendor OUT (RTL AGC uses reg 0x19 @ wIndex 0x0010). */
+inline RtlControlRecord measured_v4_demod_reg_write(uint8_t reg, uint8_t value)
+{
+    RtlControlRecord rec{};
+    rec.value = static_cast<uint16_t>((static_cast<uint16_t>(reg) << 8) | 0x20);
+    rec.index = kMeasuredV4RtlAgcWindex;
+    rec.request_type = 0x40;
+    rec.length = 1;
+    rec.data[0] = value;
     return rec;
 }
 

--- a/src/esp_rtl_sdr.cpp
+++ b/src/esp_rtl_sdr.cpp
@@ -136,8 +136,12 @@ struct esp_rtl_sdr_handle {
      */
     volatile bool pending_gain = false;
     volatile int pending_gain_tenth = 0;
+    volatile bool pending_gain_mode = false;
+    volatile esp_rtl_sdr_gain_mode_t pending_gain_mode_val = ESP_RTL_SDR_GAIN_MODE_MANUAL;
     volatile bool pending_bias = false;
     volatile bool pending_bias_enable = false;
+    volatile bool pending_rtl_agc = false;
+    volatile bool pending_rtl_agc_enable = false;
     volatile bool ep0_sideband_busy = false;
 
     /** Preferred LO/rate for desktop-shaped set_* APIs and start_hz(). */
@@ -166,6 +170,8 @@ struct esp_rtl_sdr_handle {
     esp_rtl_sdr_gain_mode_t gain_mode = ESP_RTL_SDR_GAIN_MODE_AUTO;
     int gain_tenth_db = 0;
     bool bias_tee_want = false;
+    bool rtl_agc_want = false;
+    bool tuner_auto_applied = false; /* true after AUTO trio actually written */
 
     /** Sync-read pull ring (CU8 bytes). Filled by delivery task. */
     uint8_t *pull_buf = nullptr;
@@ -1041,7 +1047,8 @@ static void delivery_task_fn(void *arg)
             (void)apply_pending_retune(h);
         }
         if (h->streaming && !h->retune_busy && !h->ep0_sideband_busy &&
-            (h->pending_gain || h->pending_bias)) {
+            (h->pending_gain || h->pending_bias || h->pending_gain_mode ||
+             h->pending_rtl_agc)) {
             (void)apply_pending_sideband_ep0(h);
         }
 
@@ -1780,7 +1787,9 @@ static esp_err_t stop_stream_internal(esp_rtl_sdr_handle *h, uint32_t timeout_ms
     h->streaming = false;
     h->pending_retune_hz = 0;
     h->pending_gain = false;
+    h->pending_gain_mode = false;
     h->pending_bias = false;
+    h->pending_rtl_agc = false;
     h->ep0_sideband_busy = false;
 
     if (h->dev != nullptr && h->bulk_num > 0) {
@@ -2993,6 +3002,53 @@ static esp_err_t apply_gain_records(esp_rtl_sdr_handle *h, int tenth_db, int *ap
     return ESP_OK;
 }
 
+/** Tuner AGC AUTO trio (caller owns bulk pause). Do not run band FE after — it
+ *  would clobber measured reg0c=0x6B back to the manual 0x68 on VHF/HF. */
+static esp_err_t apply_tuner_agc_auto_records(esp_rtl_sdr_handle *h)
+{
+    const RtlControlRecord w05 =
+        measured_v4_ir_reg_write(0x05, kMeasuredV4TunerAgcReg05);
+    const RtlControlRecord w07 =
+        measured_v4_ir_reg_write(0x07, kMeasuredV4TunerAgcReg07);
+    const RtlControlRecord w0c =
+        measured_v4_ir_reg_write(0x0c, kMeasuredV4TunerAgcReg0c);
+
+    esp_err_t err = ESP_FAIL;
+    for (int pass = 0; pass < 3; ++pass) {
+        err = run_record(h, w05, false);
+        if (err == ESP_OK) {
+            err = run_record(h, w07, false);
+        }
+        if (err == ESP_OK) {
+            err = run_record(h, w0c, false);
+        }
+        if (err == ESP_OK) {
+            return ESP_OK;
+        }
+        ESP_LOGW(TAG, "tuner AGC AUTO EP0 pass %d failed: %s", pass,
+                 esp_rtl_sdr_err_to_name(err));
+        vTaskDelay(pdMS_TO_TICKS(30 + pass * 20));
+    }
+    return err;
+}
+
+/** RTL2832 digital AGC demod 0x19 (caller owns bulk pause). */
+static esp_err_t apply_rtl_agc_records(esp_rtl_sdr_handle *h, bool enable)
+{
+    const RtlControlRecord rec = measured_v4_demod_reg_write(
+        kMeasuredV4RtlAgcReg, enable ? kMeasuredV4RtlAgcOn : kMeasuredV4RtlAgcOff);
+    esp_err_t err = ESP_FAIL;
+    for (int pass = 0; pass < 3; ++pass) {
+        err = run_record(h, rec, false);
+        if (err == ESP_OK) {
+            return ESP_OK;
+        }
+        ESP_LOGW(TAG, "RTL AGC EP0 pass %d failed: %s", pass, esp_rtl_sdr_err_to_name(err));
+        vTaskDelay(pdMS_TO_TICKS(20 + pass * 15));
+    }
+    return err;
+}
+
 /** SYS bias sequence only (caller owns bulk pause). Settle after GPIO writes. */
 static esp_err_t apply_bias_records(esp_rtl_sdr_handle *h, bool enable)
 {
@@ -3020,7 +3076,7 @@ static esp_err_t apply_bias_records(esp_rtl_sdr_handle *h, bool enable)
 }
 
 /**
- * Drain bulk once, apply any pending bias then gain, resume.
+ * Drain bulk once, apply pending bias / tuner mode / gain / RTL AGC, resume.
  * Must not run on USB client task. Coalesces stacked pending values.
  */
 static esp_err_t apply_pending_sideband_ep0(esp_rtl_sdr_handle *h)
@@ -3031,17 +3087,24 @@ static esp_err_t apply_pending_sideband_ep0(esp_rtl_sdr_handle *h)
     if (h->ep0_sideband_busy || h->retune_busy) {
         return ESP_OK;
     }
-    if (!h->pending_gain && !h->pending_bias) {
+    if (!h->pending_gain && !h->pending_bias && !h->pending_gain_mode &&
+        !h->pending_rtl_agc) {
         return ESP_OK;
     }
     h->ep0_sideband_busy = true;
 
     const bool do_bias = h->pending_bias;
     const bool bias_en = h->pending_bias_enable;
+    const bool do_mode = h->pending_gain_mode;
+    const esp_rtl_sdr_gain_mode_t mode_val = h->pending_gain_mode_val;
     const bool do_gain = h->pending_gain;
     const int gain_t = h->pending_gain_tenth;
+    const bool do_rtl = h->pending_rtl_agc;
+    const bool rtl_en = h->pending_rtl_agc_enable;
     h->pending_bias = false;
     h->pending_gain = false;
+    h->pending_gain_mode = false;
+    h->pending_rtl_agc = false;
 
     bulk_pause_and_drain(h);
 
@@ -3055,20 +3118,52 @@ static esp_err_t apply_pending_sideband_ep0(esp_rtl_sdr_handle *h)
             ESP_LOGW(TAG, "bias-T EP0 failed: %s", esp_rtl_sdr_err_to_name(err));
         }
     }
-    if (do_gain) {
+
+    /* Manual ladder (set_tuner_gain) wins over a stale AUTO queue. */
+    const bool apply_auto = do_mode && mode_val == ESP_RTL_SDR_GAIN_MODE_AUTO && !do_gain;
+    const bool apply_manual =
+        do_gain || (do_mode && mode_val == ESP_RTL_SDR_GAIN_MODE_MANUAL);
+
+    if (apply_auto) {
+        const esp_err_t aerr = apply_tuner_agc_auto_records(h);
+        if (aerr == ESP_OK) {
+            h->gain_mode = ESP_RTL_SDR_GAIN_MODE_AUTO;
+            h->tuner_auto_applied = true;
+            ESP_LOGI(TAG, "tuner AGC AUTO [measured V4, async]");
+        } else {
+            ESP_LOGW(TAG, "tuner AGC AUTO EP0 failed: %s", esp_rtl_sdr_err_to_name(aerr));
+            if (err == ESP_OK) {
+                err = aerr;
+            }
+        }
+    } else if (apply_manual) {
         int applied = 0;
-        const esp_err_t gerr = apply_gain_records(h, gain_t, &applied);
+        const int tenth = do_gain ? gain_t : h->gain_tenth_db;
+        const esp_err_t gerr = apply_gain_records(h, tenth, &applied);
         if (gerr == ESP_OK) {
             h->gain_tenth_db = applied;
             h->gain_mode = ESP_RTL_SDR_GAIN_MODE_MANUAL;
+            h->tuner_auto_applied = false;
             ESP_LOGI(TAG, "tuner gain applied %d (0.1 dB) [async]", applied);
-            /* Keep triplexer path after reg05 gain writes. */
             (void)run_band_frontend_after_gain(h, h->frequency_hz);
         } else {
-            ESP_LOGW(TAG, "tuner gain EP0 failed req=%d: %s", gain_t,
+            ESP_LOGW(TAG, "tuner gain EP0 failed req=%d: %s", tenth,
                      esp_rtl_sdr_err_to_name(gerr));
             if (err == ESP_OK) {
                 err = gerr;
+            }
+        }
+    }
+
+    if (do_rtl) {
+        const esp_err_t rerr = apply_rtl_agc_records(h, rtl_en);
+        if (rerr == ESP_OK) {
+            h->rtl_agc_want = rtl_en;
+            ESP_LOGI(TAG, "RTL AGC %s [measured demod 0x19, async]", rtl_en ? "ON" : "OFF");
+        } else {
+            ESP_LOGW(TAG, "RTL AGC EP0 failed: %s", esp_rtl_sdr_err_to_name(rerr));
+            if (err == ESP_OK) {
+                err = rerr;
             }
         }
     }
@@ -3106,6 +3201,34 @@ static esp_err_t apply_measured_v4_bias(esp_rtl_sdr_handle *h, bool enable)
     return apply_bias_records(h, enable);
 }
 
+static esp_err_t apply_measured_v4_gain_mode(esp_rtl_sdr_handle *h,
+                                             esp_rtl_sdr_gain_mode_t mode)
+{
+    if (h->streaming) {
+        h->pending_gain_mode_val = mode;
+        h->pending_gain_mode = true;
+        if (mode == ESP_RTL_SDR_GAIN_MODE_AUTO) {
+            h->pending_gain = false; /* AUTO replaces a queued ladder write */
+        }
+        return ESP_OK;
+    }
+    if (mode == ESP_RTL_SDR_GAIN_MODE_AUTO) {
+        const esp_err_t aerr = apply_tuner_agc_auto_records(h);
+        if (aerr == ESP_OK) {
+            h->tuner_auto_applied = true;
+        }
+        return aerr;
+    }
+    int applied = 0;
+    const esp_err_t err = apply_gain_records(h, h->gain_tenth_db, &applied);
+    if (err == ESP_OK) {
+        h->gain_tenth_db = applied;
+        h->tuner_auto_applied = false;
+        (void)run_band_frontend_after_gain(h, h->frequency_hz);
+    }
+    return err;
+}
+
 esp_err_t esp_rtl_sdr_set_tuner_gain_mode(esp_rtl_sdr_handle_t handle,
                                           esp_rtl_sdr_gain_mode_t mode)
 {
@@ -3115,18 +3238,44 @@ esp_err_t esp_rtl_sdr_set_tuner_gain_mode(esp_rtl_sdr_handle_t handle,
     if (mode != ESP_RTL_SDR_GAIN_MODE_AUTO && mode != ESP_RTL_SDR_GAIN_MODE_MANUAL) {
         return ESP_ERR_INVALID_ARG;
     }
+    if (check_not_reentrant(handle) != ESP_OK) {
+        return ESP_RTL_SDR_ERR_REENTRANT;
+    }
+
+    {
+        HandleLock lk(handle);
+        if (!lk.ok()) {
+            return ESP_RTL_SDR_ERR_TIMEOUT;
+        }
+        if (!handle->iface_claimed || handle->dev == nullptr) {
+            set_error_unlocked(handle, ESP_RTL_SDR_ERR_NOT_CLAIMED);
+            return ESP_RTL_SDR_ERR_NOT_CLAIMED;
+        }
+        /* Default get() is AUTO before any EP0. First AUTO after claim must write. */
+        const bool already =
+            (mode == ESP_RTL_SDR_GAIN_MODE_AUTO) ? handle->tuner_auto_applied
+                                                 : (handle->gain_mode == ESP_RTL_SDR_GAIN_MODE_MANUAL);
+        if (already && !handle->pending_gain_mode) {
+            set_error_unlocked(handle, ESP_OK);
+            return ESP_OK;
+        }
+    }
+
+    const esp_err_t err = apply_measured_v4_gain_mode(handle, mode);
+
     HandleLock lk(handle);
     if (!lk.ok()) {
-        return ESP_RTL_SDR_ERR_TIMEOUT;
+        return (err == ESP_OK) ? ESP_RTL_SDR_ERR_TIMEOUT : err;
     }
-    handle->gain_mode = mode;
-    /* AUTO AGC EP0 not in 2026-08-12 capture set — manual path only. */
-    if (mode == ESP_RTL_SDR_GAIN_MODE_AUTO) {
-        set_error_unlocked(handle, ESP_RTL_SDR_ERR_UNSUPPORTED);
-        return ESP_RTL_SDR_ERR_UNSUPPORTED;
+    if (err == ESP_OK) {
+        handle->gain_mode = mode;
+        set_error_unlocked(handle, ESP_OK);
+        ESP_LOGI(TAG, "tuner gain mode %s [measured V4]",
+                 mode == ESP_RTL_SDR_GAIN_MODE_AUTO ? "AUTO" : "MANUAL");
+    } else {
+        set_error_unlocked(handle, err);
     }
-    set_error_unlocked(handle, ESP_OK);
-    return ESP_OK;
+    return err;
 }
 
 esp_err_t esp_rtl_sdr_get_tuner_gain_mode(esp_rtl_sdr_handle_t handle,
@@ -3165,6 +3314,8 @@ esp_err_t esp_rtl_sdr_set_tuner_gain(esp_rtl_sdr_handle_t handle, int gain_tenth
             return ESP_RTL_SDR_ERR_NOT_CLAIMED;
         }
         handle->gain_mode = ESP_RTL_SDR_GAIN_MODE_MANUAL;
+        handle->pending_gain_mode = false; /* cancel queued AUTO */
+        handle->tuner_auto_applied = false;
     }
 
     int applied = 0;
@@ -3256,6 +3407,65 @@ esp_err_t esp_rtl_sdr_set_bias_tee(esp_rtl_sdr_handle_t handle, bool enable)
         set_error_unlocked(handle, err);
     }
     return err;
+}
+
+esp_err_t esp_rtl_sdr_set_rtl_agc(esp_rtl_sdr_handle_t handle, bool enable)
+{
+    if (!handle_ok(handle)) {
+        return ESP_RTL_SDR_ERR_STALE_HANDLE;
+    }
+    if (check_not_reentrant(handle) != ESP_OK) {
+        return ESP_RTL_SDR_ERR_REENTRANT;
+    }
+
+    {
+        HandleLock lk(handle);
+        if (!lk.ok()) {
+            return ESP_RTL_SDR_ERR_TIMEOUT;
+        }
+        if (!handle->iface_claimed || handle->dev == nullptr) {
+            set_error_unlocked(handle, ESP_RTL_SDR_ERR_NOT_CLAIMED);
+            return ESP_RTL_SDR_ERR_NOT_CLAIMED;
+        }
+        if (handle->streaming) {
+            handle->pending_rtl_agc_enable = enable;
+            handle->pending_rtl_agc = true;
+            handle->rtl_agc_want = enable;
+            set_error_unlocked(handle, ESP_OK);
+            return ESP_OK;
+        }
+    }
+
+    const esp_err_t err = apply_rtl_agc_records(handle, enable);
+
+    HandleLock lk(handle);
+    if (!lk.ok()) {
+        return (err == ESP_OK) ? ESP_RTL_SDR_ERR_TIMEOUT : err;
+    }
+    if (err == ESP_OK) {
+        handle->rtl_agc_want = enable;
+        set_error_unlocked(handle, ESP_OK);
+        ESP_LOGI(TAG, "RTL AGC %s [measured demod 0x19]", enable ? "ON" : "OFF");
+    } else {
+        set_error_unlocked(handle, err);
+    }
+    return err;
+}
+
+esp_err_t esp_rtl_sdr_get_rtl_agc(esp_rtl_sdr_handle_t handle, bool *out_enable)
+{
+    if (out_enable == nullptr) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (!handle_ok(handle)) {
+        return ESP_RTL_SDR_ERR_STALE_HANDLE;
+    }
+    HandleLock lk(handle, kQueryLockTicks);
+    if (!lk.ok()) {
+        return ESP_RTL_SDR_ERR_TIMEOUT;
+    }
+    *out_enable = handle->rtl_agc_want;
+    return ESP_OK;
 }
 
 esp_err_t esp_rtl_sdr_get_bias_tee(esp_rtl_sdr_handle_t handle, bool *out_enable)

--- a/src/esp_rtl_sdr_policy.cpp
+++ b/src/esp_rtl_sdr_policy.cpp
@@ -37,14 +37,16 @@ const char *esp_rtl_sdr_get_version_string(void)
 uint32_t esp_rtl_sdr_get_capabilities(void)
 {
     /* MEASURED_2026_08_12: CAP_GAIN + CAP_BIAS_TEE from lab USBPcap (Blog V4).
-     * 0.7.7: CAP_HF_UPCONVERTER — public V4 HF path (RF+28.8e6) + measured band FE. */
+     * 0.7.7: CAP_HF_UPCONVERTER — public V4 HF path (RF+28.8e6) + measured band FE.
+     * MEASURED_2026_08_26: CAP_GAIN_AUTO + CAP_RTL_AGC (tuner 05/07/0c + demod 0x19). */
     return ESP_RTL_SDR_CAP_STREAM | ESP_RTL_SDR_CAP_RETUNE | ESP_RTL_SDR_CAP_METRICS |
            ESP_RTL_SDR_CAP_CUSTOM_HZ | ESP_RTL_SDR_CAP_HOTPLUG |
            ESP_RTL_SDR_CAP_FREQ_CORRECTION | ESP_RTL_SDR_CAP_MULTI_DEVICE |
            ESP_RTL_SDR_CAP_SYNC_READ | ESP_RTL_SDR_CAP_CONTINUOUS_RATE |
            ESP_RTL_SDR_CAP_NEED | ESP_RTL_SDR_CAP_HEALTH | ESP_RTL_SDR_CAP_PASSPORT |
            ESP_RTL_SDR_CAP_DELIVERY_MODE | ESP_RTL_SDR_CAP_GAIN | ESP_RTL_SDR_CAP_BIAS_TEE |
-           ESP_RTL_SDR_CAP_HF_UPCONVERTER;
+           ESP_RTL_SDR_CAP_HF_UPCONVERTER | ESP_RTL_SDR_CAP_GAIN_AUTO |
+           ESP_RTL_SDR_CAP_RTL_AGC;
 }
 
 bool esp_rtl_sdr_delivery_mode_uses_callback_iq(esp_rtl_sdr_delivery_mode_t mode)

--- a/tests/host/CMakeLists.txt
+++ b/tests/host/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(esp_rtl_sdr_host_tests
 target_include_directories(esp_rtl_sdr_host_tests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/stubs
     ${CMAKE_CURRENT_SOURCE_DIR}/../../include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../private
 )
 
 if(MSVC)

--- a/tests/host/test_policy.cpp
+++ b/tests/host/test_policy.cpp
@@ -11,6 +11,7 @@
 #include <string>
 
 #include "esp_rtl_sdr.h"
+#include "measured_gain_bias_v4.hpp"
 
 static int g_failed = 0;
 static int g_passed = 0;
@@ -103,9 +104,57 @@ static void test_capabilities(void)
     EXPECT_TRUE((c & ESP_RTL_SDR_CAP_GAIN) != 0);
     /* 0.7.7 HF upconverter path */
     EXPECT_TRUE((c & ESP_RTL_SDR_CAP_HF_UPCONVERTER) != 0);
+    /* 0.7.8 measured Tuner AUTO + RTL digital AGC */
+    EXPECT_TRUE((c & ESP_RTL_SDR_CAP_GAIN_AUTO) != 0);
+    EXPECT_TRUE((c & ESP_RTL_SDR_CAP_RTL_AGC) != 0);
     /* Still reserved */
     EXPECT_TRUE((c & ESP_RTL_SDR_CAP_DIRECT_SAMPLING) == 0);
     EXPECT_TRUE((c & ESP_RTL_SDR_CAP_IQ_ACQUIRE) == 0);
+}
+
+static void test_measured_agc_tables(void)
+{
+    /* Tuner AUTO trio is not a manual ladder step. */
+    EXPECT_EQ_U(kMeasuredV4TunerAgcReg05, 0xe8);
+    EXPECT_EQ_U(kMeasuredV4TunerAgcReg07, 0x78);
+    EXPECT_EQ_U(kMeasuredV4TunerAgcReg0c, 0x6b);
+    EXPECT_TRUE(kMeasuredV4TunerAgcReg0c != kMeasuredV4GainReg0c);
+
+    bool auto_matches_manual = false;
+    for (size_t i = 0; i < kMeasuredV4GainStepCount; ++i) {
+        if (kMeasuredV4GainSteps[i].reg05 == kMeasuredV4TunerAgcReg05 &&
+            kMeasuredV4GainSteps[i].reg07 == kMeasuredV4TunerAgcReg07) {
+            auto_matches_manual = true;
+        }
+    }
+    EXPECT_TRUE(!auto_matches_manual);
+
+    /* 29.7 dB parked UI during capture is still on the manual ladder. */
+    const size_t i297 = measured_v4_nearest_gain_index(297);
+    EXPECT_EQ_I(kMeasuredV4GainSteps[i297].tenth_db, 297);
+    EXPECT_EQ_U(kMeasuredV4GainSteps[i297].reg05, 0xf7);
+    EXPECT_EQ_U(kMeasuredV4GainSteps[i297].reg07, 0x67);
+
+    EXPECT_EQ_U(kMeasuredV4RtlAgcWvalue, 0x1920);
+    EXPECT_EQ_U(kMeasuredV4RtlAgcWindex, 0x0010);
+    EXPECT_EQ_U(kMeasuredV4RtlAgcOn, 0x25);
+    EXPECT_EQ_U(kMeasuredV4RtlAgcOff, 0x05);
+    EXPECT_TRUE(kMeasuredV4RtlAgcOn != kMeasuredV4RtlAgcOff);
+
+    const RtlControlRecord ir = measured_v4_ir_reg_write(0x05, kMeasuredV4TunerAgcReg05);
+    EXPECT_EQ_U(ir.value, 0x0074);
+    EXPECT_EQ_U(ir.index, 0x0610);
+    EXPECT_EQ_U(ir.request_type, 0x40);
+    EXPECT_EQ_U(ir.length, 2);
+    EXPECT_EQ_U(ir.data[0], 0x05);
+    EXPECT_EQ_U(ir.data[1], 0xe8);
+
+    const RtlControlRecord dem =
+        measured_v4_demod_reg_write(kMeasuredV4RtlAgcReg, kMeasuredV4RtlAgcOn);
+    EXPECT_EQ_U(dem.value, 0x1920);
+    EXPECT_EQ_U(dem.index, 0x0010);
+    EXPECT_EQ_U(dem.length, 1);
+    EXPECT_EQ_U(dem.data[0], 0x25);
 }
 
 static void test_rate_windows(void)
@@ -465,6 +514,7 @@ int main(void)
     std::printf("esp_rtl_sdr host policy tests (%s)\n", esp_rtl_sdr_get_version_string());
     test_version();
     test_capabilities();
+    test_measured_agc_tables();
     test_delivery_mode_helpers();
     test_rate_windows();
     test_recommended_rates();

--- a/tests/scripts/check_truth_hygiene.sh
+++ b/tests/scripts/check_truth_hygiene.sh
@@ -75,6 +75,16 @@ if grep -E 'ESP_RTL_SDR_CAP_GAIN|ESP_RTL_SDR_CAP_BIAS_TEE' src/esp_rtl_sdr_polic
     exit 1
   fi
 fi
+if grep -E 'ESP_RTL_SDR_CAP_GAIN_AUTO|ESP_RTL_SDR_CAP_RTL_AGC' src/esp_rtl_sdr_policy.cpp | grep -v '//' >/dev/null; then
+  if ! grep -q 'MEASURED_2026_08_26' src/esp_rtl_sdr_policy.cpp; then
+    echo "CAP_GAIN_AUTO/RTL_AGC enabled without MEASURED_2026_08_26 marker in policy"
+    exit 1
+  fi
+  if ! grep -q 'kMeasuredV4TunerAgcReg05' private/measured_gain_bias_v4.hpp; then
+    echo "missing measured Tuner AGC constants"
+    exit 1
+  fi
+fi
 
 # Host test sources present
 test -f tests/host/test_policy.cpp


### PR DESCRIPTION
## Why

Lab USBPcap 2026-08-26 captured Tuner AGC and RTL AGC on a Blog V4. This PR implements **only those bytes**. SDR# Bandwidth produced no vendor USB after open, so there is still no IF-filter CAP.

## Behavior (drop-in)

- **MANUAL** `set_tuner_gain` / ladder: unchanged.
- **`set_tuner_gain_mode(AUTO)`**: no longer `ERR_UNSUPPORTED`. Writes measured IR `05=E8 07=78 0C=6B` after claim. Check `CAP_GAIN_AUTO`.
- **`set_tuner_gain`**: still forces MANUAL and cancels a queued AUTO.
- **`set/get_rtl_agc`**: additive API (`CAP_RTL_AGC`). Apps that never call it are unchanged.
- Same async bulk-pause sideband queue as 0.7.6 gain/bias.
- First AUTO after start actually writes EP0 (default get() AUTO is a preference, not applied hardware).
- After AUTO, skip triplexer filter rewrite (would clobber `0x0c=0x6B`).

## Evidence

| Capture | Result |
|---|---|
| `agc_tuner_on_off.pcapng` | 4 clusters AUTO ON `05=E8 07=78 0C=6B` |
| `agc_rtl_on_off.pcapng` | demod `0x19` ON=`0x25` OFF=`0x05` |
| `if_filters_steps.pcapng` | USB silent after open |

Procedure: `docs/AGC_IF_CAPTURE.md`.

## Tests

- Host table tests for AUTO trio vs manual ladder, RTL AGC constants, IR/demod record builders.
- `check_truth_hygiene.sh` requires `MEASURED_2026_08_26` when `CAP_GAIN_AUTO` / `CAP_RTL_AGC` are on.
- P4 USB re-soak still open (same honesty as 0.7.5 gain).

## Not in this PR

- Hardware IF filter CAP
- librtlsdr source
- Changing existing MANUAL dB ladder