### PR TITLE
0.7.8 bookmark: AUTO/RTL AGC, Tab5 L4 report, task-local REENTRANT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed
+
+- **False `ERR_REENTRANT`:** reentrancy is the **callback task**, not a handle-wide
+  depth flag. App-task `set_tuner_gain_mode` / gain / bias / RTL AGC no longer fail
+  while the delivery task is emitting `EVT_IQ_BLOCK`. Tab5 L4 run 1 reproduced this
+  (`docs/Test_reports/ESP_RTL_SDR_0_7_8_DROP_IN_TEST_REPORT_2026-08-26.md`).
+  `retune_hz` async-from-callback uses the same task check.
+
 ## 0.7.8 (2026-08-26)
 
 ### Added — measured Tuner AGC AUTO + RTL digital AGC

--- a/PROJECT_TRUTH.md
+++ b/PROJECT_TRUTH.md
@@ -83,6 +83,7 @@ Product vision: **`docs/VISION.md`**. Silicon / DS map: **`docs/SILICON.md`**.
 | Tuner AGC AUTO | **Implemented (measured 2026-08-26)** | CAP_GAIN_AUTO; `set_tuner_gain_mode(AUTO)`; P4 re-soak open |
 | RTL digital AGC | **Implemented (measured 2026-08-26)** | CAP_RTL_AGC; additive `set_rtl_agc`; not tuner AUTO |
 | Gain/AGC/bias getters | **Requested-state shadow** | Live setters are **async** (delivery-task EP0). `get_*` is not a hardware register readback. Smoke can prove API + IQ/metrics around transitions, not that every URB landed. |
+| Callback reentrancy | **Fix in tree (unreleased)** | `ERR_REENTRANT` is calling-task only. Tab5 L4 run 1 hit false REENTRANT on app-task MANUAL while IQ callbacks ran. |
 | R828D IF / SDR# Bandwidth | **No USB** (2026-08-26 capture) | Software-only; no CAP_IF_FILTER |
 | set/get center freq, rate, ppm | **Implemented** | |
 | Sync `read()` | **Implemented** | |

--- a/PROJECT_TRUTH.md
+++ b/PROJECT_TRUTH.md
@@ -82,6 +82,7 @@ Product vision: **`docs/VISION.md`**. Silicon / DS map: **`docs/SILICON.md`**.
 | Gain / bias public API | **Implemented (measured V4)** | CAP_GAIN + CAP_BIAS_TEE **on**; P4 re-soak open |
 | Tuner AGC AUTO | **Implemented (measured 2026-08-26)** | CAP_GAIN_AUTO; `set_tuner_gain_mode(AUTO)`; P4 re-soak open |
 | RTL digital AGC | **Implemented (measured 2026-08-26)** | CAP_RTL_AGC; additive `set_rtl_agc`; not tuner AUTO |
+| Gain/AGC/bias getters | **Requested-state shadow** | Live setters are **async** (delivery-task EP0). `get_*` is not a hardware register readback. Smoke can prove API + IQ/metrics around transitions, not that every URB landed. |
 | R828D IF / SDR# Bandwidth | **No USB** (2026-08-26 capture) | Software-only; no CAP_IF_FILTER |
 | set/get center freq, rate, ppm | **Implemented** | |
 | Sync `read()` | **Implemented** | |

--- a/README.md
+++ b/README.md
@@ -243,8 +243,8 @@ Design contract: [`docs/API.md`](docs/API.md) · header: [`include/esp_rtl_sdr.h
 | API | Today |
 |---|---|
 | `set/get_tuner_gain` · `get_tuner_gains` | Manual ladder 0.0…49.6 dB (CAP_GAIN); need claimed stream |
-| `set_tuner_gain_mode(MANUAL\|AUTO)` | MANUAL ladder; AUTO measured R828D AGC (`CAP_GAIN_AUTO`, 0.7.8+) |
-| `set/get_rtl_agc` | RTL2832 digital AGC (`CAP_RTL_AGC`); not tuner AUTO |
+| `set_tuner_gain_mode(MANUAL\|AUTO)` | MANUAL ladder; AUTO measured R828D AGC (`CAP_GAIN_AUTO`, 0.7.8+). Streaming = async EP0. |
+| `set/get_rtl_agc` | RTL2832 digital AGC (`CAP_RTL_AGC`); not tuner AUTO. **get** = requested shadow, not readback. |
 | `set/get_bias_tee` | Measured SYS EP0 (CAP_BIAS_TEE); need claimed stream |
 | HF (0.7.7) | **500 kHz…1766 MHz**; RF&lt;28.8 MHz uses +28.8 MHz upconverter (`CAP_HF_UPCONVERTER`) |
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -156,6 +156,8 @@ Prefer component codes over generic `INVALID_STATE` when the app can branch:
 | `read` | Blocking CU8 IQ |
 | `start_hz` | Convenience start (0 = preferred) |
 | `set/get_freq_correction` | ±200 ppm software LO |
+| Gain / AUTO / RTL AGC / bias **set** | Claimed stream; **async** while streaming (bulk pause + EP0 on delivery task). `ESP_OK` = accepted |
+| Gain / AUTO / RTL AGC / bias **get** | Last **requested** shadow — **not** EP0/I2C readback |
 | Multi-device APIs | refresh / count / at / select |
 | `apply_need` | Mission presets → preferred LO/rate |
 | `get_health` | USB/RF categories + advice |

--- a/docs/API.md
+++ b/docs/API.md
@@ -16,7 +16,7 @@ For every function’s parameters, return semantics, and copy-paste examples, us
 |---|---|
 | Works every time | Strict validation; no half-open USB; fail closed to IDLE/FAULT |
 | Safe under concurrency | Per-handle mutex; RAII locks; short timeouts on queries |
-| No callback re-entry | `in_callback_depth` → `ERR_REENTRANT` on lifecycle APIs |
+| No callback re-entry | `ERR_REENTRANT` only if **this task** is inside the event callback. App tasks may set gain/mode while delivery emits. |
 | Events outside lock | Callbacks run only after mutex release |
 | Stable ABI growth | `struct_size` on config structs; new fields only at end |
 | Clear failures | Component error codes + `err_to_name` + `get_last_error` |

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1221,13 +1221,20 @@ P4 re-soak and multimeter DC are still lab-open — see [`PHASE3_CAPTURE_REPORT.
 |---|---|
 | `set_tuner_gain_mode(MANUAL)` | Restore last ladder step (or 0.0 dB); no-op if already MANUAL |
 | `set_tuner_gain_mode(AUTO)` | **0.7.8+** measured IR `05=E8 07=78 0C=6B` (`CAP_GAIN_AUTO`) |
-| `get_tuner_gain_mode` | Last mode |
+| `get_tuner_gain_mode` | Last **requested** mode — not register readback |
 | `set_tuner_gain` | Nearest measured step; forces MANUAL; cancels queued AUTO |
-| `get_tuner_gain` | Last applied step (0 if never set) |
+| `get_tuner_gain` | Last requested/accepted step (0 if never set) — software shadow |
 | `get_tuner_gains` | 28 steps: 0…496 tenths dB (0.0…49.6 dB) |
 | `set_bias_tee` | SYS sequence `3004/3003/3001/3000` (ON: 3001=0x19, OFF: 0x18) |
 | `get_bias_tee` | Last requested preference |
-| `set/get_rtl_agc` | **0.7.8+** demod `0x19` ON=`0x25` OFF=`0x05` (`CAP_RTL_AGC`) |
+| `set/get_rtl_agc` | **0.7.8+** demod `0x19` ON=`0x25` OFF=`0x05` (`CAP_RTL_AGC`); get is shadow |
+
+While streaming, gain / mode / bias / RTL AGC **setters are async** (delivery task,
+one bulk-pause window). `ESP_OK` means the request was queued or applied on the
+non-streaming path — **not** that the device ACKed each EP0 byte. A smoke app
+can prove API returns, continued IQ, metrics, and health around each transition.
+It **cannot** independently prove every register write landed. USBPcap on a PC
+(or a future explicit readback CAP) is the evidence for EP0 contents.
 
 ```c
 if (esp_rtl_sdr_get_capabilities() & ESP_RTL_SDR_CAP_GAIN) {

--- a/docs/HANDOFF_0_7_8_TEST.md
+++ b/docs/HANDOFF_0_7_8_TEST.md
@@ -128,6 +128,7 @@ Apps written against 0.7.5–0.7.7 that **never call AUTO**:
 6. Unclaimed AUTO → `ERR_NOT_CLAIMED` (not UNSUPPORTED).
 7. From IQ callback → `ERR_REENTRANT` (same as `set_tuner_gain`).
 8. Default `get_tuner_gain_mode()` may still read AUTO before any EP0. First explicit AUTO after `start` **must** write hardware (`tuner_auto_applied` flag). Treating “default AUTO” as already applied is a bug.
+9. `ERR_REENTRANT` is **callback-task only**. An app task must not get REENTRANT solely because `EVT_IQ_BLOCK` is running on the delivery task (Tab5 L4 run 1).
 
 ---
 

--- a/docs/HANDOFF_0_7_8_TEST.md
+++ b/docs/HANDOFF_0_7_8_TEST.md
@@ -1,0 +1,438 @@
+# Handoff — 0.7.8 test plan + Codex prompt
+
+**Audience:** next Codex / Grok / human lab session.  
+**Date:** 2026-08-26  
+**Driver repo:** `F:\Ai\ESP_RTL_SDR` → https://github.com/hardcoreerik/esp-rtl-sdr  
+**Branch / SHA:** `master` **`b74bbfe`** (PR [#7](https://github.com/hardcoreerik/esp-rtl-sdr/pull/7) merged)  
+**Version in tree:** **0.7.8**  
+**PROJECT_TRUTH wins** if anything here disagrees.
+
+> **Driver EP0 is already implemented.** Do **not** re-derive Tuner AUTO / RTL AGC
+> from librtlsdr. Do **not** invent IF-filter CAP. This handoff is: **test
+> harness + consumer drop-in + lab evidence**.
+
+---
+
+## 0. Copy-paste prompt for Codex
+
+```text
+Work only in F:\Ai\ESP_RTL_SDR unless Phase B explicitly says to touch OrcSDR.
+
+Read first, in order:
+1. PROJECT_TRUTH.md
+2. docs/HANDOFF_0_7_8_TEST.md          (this file — test plan is law)
+3. docs/CLEAN_ROOM.md
+4. docs/AGC_IF_CAPTURE.md             (measured bytes; IF was USB-silent)
+5. include/esp_rtl_sdr.h              (0.7.8 CAP_GAIN_AUTO, CAP_RTL_AGC, set_rtl_agc)
+6. examples/p4_serial_smoke/main/main.c
+7. docs/TESTING_GUIDE.md
+8. docs/SOAK.md + docs/lab/SOAK_LOG_TEMPLATE.md
+
+Context (do not re-litigate):
+- esp_rtl_sdr 0.7.8 is ON master (b74bbfe / PR #7). CI green (hygiene, host tests
+  Win+Ubuntu, P4 compile IDF 5.3.2 + 5.4.1).
+- Tuner AUTO: measured IR 05=E8 07=78 0C=6B. CAP_GAIN_AUTO.
+- RTL digital AGC: demod 0x19 ON=0x25 OFF=0x05. CAP_RTL_AGC. Additive API.
+- SDR# Bandwidth / IF filter: USB silent after open. NO CAP_IF_FILTER. Ever.
+- MANUAL ladder + bias-T unchanged. Drop-in: apps that only use MANUAL/GAIN/BIAS
+  must keep working. Do not rename APIs. Do not change CAP_GAIN meaning.
+- Clean-room: no librtlsdr / osmocom / kvhnuke register paste.
+- Do not mark Hardware-verified in PROJECT_TRUTH until a soak log from THIS tree
+  exists. Implemented ≠ Hardware-verified.
+
+Your job is NOT to re-implement AUTO EP0. Your job is:
+
+Phase A — this repo (required)
+1. Extend examples/p4_serial_smoke so that AFTER a successful start() it
+   exercises 0.7.8 AGC APIs and prints a SMOKE-style PASS/FAIL matrix
+   (see §4 of HANDOFF_0_7_8_TEST.md). Keep existing helper/install/need/read
+   behavior. If no dongle, start→NO_DEVICE and SKIP hardware AGC rows (do not
+   FAIL them). If dongle present, run T5–T14.
+2. Optional but preferred: a tiny serial CLI on UART (115200) so a human can
+   type GAIN / GAINMODE / RTLAGC / METRICS / STOP without rebuilding. If you
+   add CLI, keep one-shot matrix as well (CI compile must still succeed).
+3. Host tests already cover table constants. Add only policy tests that stay
+   host-linkable (no USB). Do not try to unit-test EP0 on the PC.
+4. Update examples/p4_serial_smoke/README.md with the new serial/smoke output.
+5. Do not commit esp_rtl_sdr.zip. Do not vendor pcapng (hundreds of MB).
+
+Phase B — OrcSDR consumer (only if the user confirms; different workspace)
+Path: F:\Ai\OrcSDR_Waveshare
+- It currently pins esp_rtl_sdr 0.7.5 via file:// F:/Ai/ESP_RTL_SDR.
+- cmd_print_caps does NOT print GAIN_AUTO / RTL_AGC / HF bits.
+- cmd_smoke_gain_bias() currently REQUIRES AUTO to return ERR_UNSUPPORTED
+  (check "gain_mode_auto_unsupported"). After 0.7.8 that check is a FALSE FAIL.
+  Invert it: AUTO must return ESP_OK; add CAP_GAIN_AUTO / CAP_RTL_AGC checks;
+  add RTLAGC ON|OFF command. Do not confuse Serial "AGC ON|OFF" (FM DSP audio)
+  with tuner AUTO or set_rtl_agc.
+- Rebuild/flash Waveshare P4 only when the user has the board.
+
+Phase C — lab (human + you logging)
+Execute §5 script. Fill docs/lab/SOAK_P4_AGC_YYYYMMDD.md from the template.
+Only then update PROJECT_TRUTH labels (Implemented stays; Hardware-verified
+only with that log).
+
+Rules:
+- Fail closed. Unknown dongle still ERR_NOT_V4.
+- Do not enable CAP bits that are not implemented.
+- Prefer same-PR docs+code. Verbose serial logs. No oversell.
+- If you change public headers, bump is already 0.7.8 — do not bump to 0.7.9
+  unless you add another CAP/API.
+
+When done: host tests + hygiene green, smoke still compiles for esp32p4,
+commit on a feature branch, PR against master.
+```
+
+---
+
+## 1. What is already true (do not redo)
+
+| Item | State |
+|---|---|
+| Tuner AUTO EP0 tables | `private/measured_gain_bias_v4.hpp` (`kMeasuredV4TunerAgcReg*`) |
+| RTL AGC tables | same file (`kMeasuredV4RtlAgc*`) |
+| `set_tuner_gain_mode(AUTO)` | Applies after claim; async sideband queue while streaming |
+| `set_rtl_agc` / `get_rtl_agc` | Additive |
+| `CAP_GAIN_AUTO` bit 18, `CAP_RTL_AGC` bit 19 | On in `esp_rtl_sdr_get_capabilities()` |
+| IF filter CAP | **Off.** Capture USB-silent. |
+| CI | Green on PR #7 |
+| P4 USB re-soak of AUTO | **Still open** |
+| `examples/p4_serial_smoke` | Compiles; **does not** call AUTO / `set_rtl_agc` yet |
+| OrcSDR Waveshare | Still docs **0.7.5**; SMOKE **expects AUTO = UNSUPPORTED** (will false-fail on 0.7.8) |
+
+Measured AUTO trio (do not “improve” from memory):
+
+```text
+reg 0x05 = 0xE8
+reg 0x07 = 0x78
+reg 0x0C = 0x6B     # manual ladder 0x0C is always 0x68
+```
+
+RTL AGC:
+
+```text
+wValue 0x1920  wIndex 0x0010  data ON=0x25  OFF=0x05
+```
+
+---
+
+## 2. Drop-in contract (break these = bug)
+
+Apps written against 0.7.5–0.7.7 that **never call AUTO**:
+
+1. `CAP_GAIN` still means **manual ladder**. Do not overload it.
+2. `set_tuner_gain` still forces MANUAL and still needs a claimed stream.
+3. Bias-T, retune, rates, HF upconverter, delivery modes: unchanged.
+4. New bits are **additive**. Old `CAPS` printers that only mask known bits stay valid.
+5. `set_tuner_gain_mode(AUTO)` **behavior change:** was `ERR_UNSUPPORTED`, now `ESP_OK` after `start`. That is intentional 0.7.8. Consumers that asserted UNSUPPORTED **must** be updated (OrcSDR SMOKE).
+6. Unclaimed AUTO → `ERR_NOT_CLAIMED` (not UNSUPPORTED).
+7. From IQ callback → `ERR_REENTRANT` (same as `set_tuner_gain`).
+8. Default `get_tuner_gain_mode()` may still read AUTO before any EP0. First explicit AUTO after `start` **must** write hardware (`tuner_auto_applied` flag). Treating “default AUTO” as already applied is a bug.
+
+---
+
+## 3. Test layers (what proves what)
+
+| ID | Layer | Environment | Proves | Does not prove |
+|---|---|---|---|---|
+| L0 | Hygiene | `tests/scripts/check_truth_hygiene.sh` | Version 0.7.8 everywhere; MEASURED_2026_08_26 marker | USB |
+| L1 | Host policy | `tests/host` | AUTO trio ≠ any manual step; RTL constants; CAP bits | EP0 |
+| L2 | IDF compile | `examples/p4_serial_smoke` esp32p4 | New symbols link | Runtime |
+| L3 | Fail-closed | P4, **no** dongle | `NO_DEVICE`; no FAULT hang | AGC |
+| L4 | Stream + AGC matrix | P4 + Blog V4 | EP0 + USB still alive | Hours-long soak |
+| L5 | Consumer | OrcSDR Waveshare | Drop-in + SMOKE | This repo isolation |
+| L6 | Soak | ≥ 15 min then ≥ 1 h | Overruns bounded | Production warranty |
+
+L0–L2 are CI. L3–L6 are lab. **Bugs in 0.7.8 AGC live in L4.**
+
+---
+
+## 4. Phase A — smoke matrix (implement this)
+
+After `esp_rtl_sdr_start` returns `ESP_OK`, run the following and log each line
+`SMOKE <name> PASS|FAIL`. If start is `NO_DEVICE`, print `SMOKE skip hardware (NO_DEVICE)` and still PASS the overall smoke (helpers already ran).
+
+Use `esp_rtl_sdr_err_to_name` on every `esp_err_t`.
+
+### 4.1 Capability discovery
+
+| Name | Assert |
+|---|---|
+| `CAP_GAIN` | bit 15 on |
+| `CAP_GAIN_AUTO` | bit 18 on |
+| `CAP_RTL_AGC` | bit 19 on |
+| `CAP_BIAS_TEE` | on |
+| `version` | `esp_rtl_sdr_get_version_string()` is `0.7.8` |
+
+### 4.2 Fail-closed (may run even after start if you also test a second handle — optional)
+
+On the **live** handle:
+
+| Name | Call | Expect |
+|---|---|---|
+| `auto_from_callback` | If easy: skip; else document “not automated” | `ERR_REENTRANT` if called from `event_cb` |
+
+Before start is already over in current smoke. Optional extra: a dedicated
+unclaimed probe is **not** required if we document that `NOT_CLAIMED` is covered
+by calling AUTO only after start in this matrix, and OrcSDR GAINMODE before START.
+
+### 4.3 MANUAL regression (must not break 0.7.5)
+
+| Name | Call | Expect |
+|---|---|---|
+| `gain_mode_manual` | `set_tuner_gain_mode(MANUAL)` | `ESP_OK` |
+| `set_gain_0` | `set_tuner_gain(0)` | `ESP_OK`; `get_tuner_gain` nearest 0 |
+| `set_gain_297` | `set_tuner_gain(297)` | `ESP_OK`; applied 297 (29.7 dB — capture parked value) |
+| `set_gain_400` | `set_tuner_gain(400)` | `ESP_OK`; applied 402 or 400 per ladder (40.2 dB is 402) |
+| `get_mode_manual` | `get_tuner_gain_mode` | `MANUAL` |
+
+Log `get_metrics` overruns **before** this block and **after**. Overrun delta of a few is noise; a large jump or FAULT is FAIL.
+
+### 4.4 Tuner AUTO (the new path)
+
+Wait ≥ 200 ms between mode changes so the delivery task can drain bulk + EP0.
+
+| Name | Call | Expect |
+|---|---|---|
+| `gain_mode_auto` | `set_tuner_gain_mode(AUTO)` | `ESP_OK` (**not** UNSUPPORTED) |
+| `get_mode_auto` | `get_tuner_gain_mode` | `AUTO` |
+| `auto_idempotent` | AUTO again immediately | `ESP_OK` (no-op after first apply) |
+| `stream_alive_after_auto` | `read` 4 KiB, timeout 1000 ms | `ESP_OK` and `n > 0` |
+| `gain_forces_manual` | `set_tuner_gain(297)` then `get_tuner_gain_mode` | `ESP_OK` and mode `MANUAL` |
+| `auto_again` | AUTO after that | `ESP_OK` |
+| `manual_restore` | `set_tuner_gain_mode(MANUAL)` | `ESP_OK`; stream still `read`s |
+
+### 4.5 RTL digital AGC (additive)
+
+| Name | Call | Expect |
+|---|---|---|
+| `rtl_agc_on` | `set_rtl_agc(true)` | `ESP_OK` |
+| `rtl_agc_get_on` | `get_rtl_agc` | true |
+| `rtl_agc_off` | `set_rtl_agc(false)` | `ESP_OK` |
+| `rtl_agc_get_off` | `get_rtl_agc` | false |
+| `rtl_agc_independent` | AUTO tuner, then `set_rtl_agc(true)` | both `ESP_OK`; tuner mode still AUTO |
+| `stream_alive_after_rtl_agc` | `read` 4 KiB | `n > 0` |
+
+### 4.6 USB health (bug hunt)
+
+After the matrix, log:
+
+```
+metrics.bytes_received
+metrics.overruns
+metrics.consumer_drops
+metrics.effective_sps
+health.overall
+health.advice
+```
+
+**FAIL** if: `FAULT`, `ERR_USB`, overruns grow unbounded during the ~2 s matrix, or `read` returns 0 after AUTO.
+
+**Do not FAIL** on RF clip/weak — antenna is optional for USB-path bugs.
+
+### 4.8 Honesty bound (do not overclaim)
+
+Live **setters** (gain, tuner AUTO, RTL AGC, bias) are **asynchronous** while
+streaming. **Getters** return the driver’s requested-state shadow, not a
+hardware-register readback.
+
+The smoke **may** claim:
+
+- `ESP_OK` / `NOT_CLAIMED` / `REENTRANT` contract
+- CAP bits and version string
+- IQ `read` still returns bytes after a transition
+- metrics / health did not explode
+
+The smoke **must not** claim:
+
+- “AUTO trio was verified on the R828D”
+- “demod 0x19 read back as 0x25”
+- Hardware-verified EP0 from getters matching USBPcap
+
+EP0 contents were proven on the **PC capture** (`docs/AGC_IF_CAPTURE.md`). P4
+path: infer from API + stream survival until a soak log or a future readback CAP.
+
+### 4.7 Suggested serial CLI (if implemented)
+
+Keep commands short, uppercase, one line:
+
+```
+HELP
+CAPS
+START / STOP
+FREQ <hz>
+GAIN <tenth>
+GAIN?
+GAINMODE MANUAL|AUTO
+RTLAGC ON|OFF | RTLAGC?
+METRICS
+HEALTH
+SMOKE
+```
+
+115200 8N1. Do not block the USB owner task in the CLI.
+
+---
+
+## 5. Lab script (human + Codex logging)
+
+Gear: Waveshare P4 (or Tab5), Blog V4 on **USB Host** (Waveshare: lower-left Type-A by Ethernet, OTG jumper HOST). Console on Type-C CH343. Antenna on 96.1 MHz if you want RF, not required for USB bugs.
+
+### 5.1 Build this tree
+
+```text
+cd F:\Ai\ESP_RTL_SDR\examples\p4_serial_smoke
+idf.py set-target esp32p4
+idf.py build
+idf.py -p COMx flash monitor
+```
+
+Expect boot log `esp_rtl_sdr 0.7.8`. If it says 0.7.7, wrong tree.
+
+### 5.2 No-dongle pass
+
+Unplug Blog V4. `start -> ESP_RTL_SDR_ERR_NO_DEVICE`. Process must reach `smoke complete` / CLI prompt. Hang = lifecycle bug.
+
+### 5.3 Dongle pass
+
+Plug Blog V4. Reboot or wait for hotplug if implemented.
+
+Run SMOKE matrix (one-shot or `SMOKE` command).
+
+Then interactive (if CLI exists):
+
+```
+GAINMODE AUTO
+METRICS          # wait 3s, METRICS again — overruns should not explode
+GAINMODE MANUAL
+GAIN 297
+RTLAGC ON
+RTLAGC OFF
+FREQ 1090000000  # retune while streaming if API used via retune_hz / set_center_freq
+METRICS
+STOP
+START
+GAINMODE AUTO
+```
+
+Listen (optional): 96.1 WFM in OrcSDR. AUTO should not permanently mute; MANUAL + GAIN 297 should sound like the capture session.
+
+### 5.4 HF + AUTO (optional, honest)
+
+`FREQ 10000000` (WWV) if `CAP_HF_UPCONVERTER`. Then `GAINMODE AUTO`.
+
+Known risk: we **skip** triplexer filter rewrite after AUTO so `0x0C=0x6B` is not smashed. HF may sound odd on AUTO. **Document**, do not “fix” by writing 0x68 after AUTO. MANUAL after AUTO should restore ladder + band FE.
+
+### 5.5 OrcSDR (Phase B)
+
+Today:
+
+```
+CAPS ... gain=1 ...          # does not print GAIN_AUTO
+SMOKE gain_mode_auto_unsupported PASS   # on 0.7.7
+```
+
+On 0.7.8 **without** OrcSDR patch, that SMOKE row **FAILS** even if the driver is correct.
+
+After patch:
+
+```
+MODE FM
+START
+CAPS                         # gain_auto=1 rtl_agc=1
+SMOKE                        # AUTO must PASS as ESP_OK
+GAINMODE AUTO
+GAINMODE MANUAL
+```
+
+Serial `AGC ON|OFF` is **FM audio DSP**. Never wire that to `set_tuner_gain_mode` or `set_rtl_agc`.
+
+---
+
+## 6. Bug catalog (what to file vs ignore)
+
+| Symptom | Verdict |
+|---|---|
+| AUTO → `ERR_UNSUPPORTED` | App/binary is 0.7.7. Not a 0.7.8 driver bug. |
+| AUTO before START → `NOT_CLAIMED` | Correct. |
+| AUTO from event_cb → `REENTRANT` | Correct. |
+| Stream dies when AUTO | **Bug** — sideband pause/queue. |
+| Overruns +10 while toggling, then flat | Likely OK (one drain window). |
+| Overruns climb every toggle with no bound | **Bug**. |
+| AUTO then `0x0C` band FE restored to 0x68 | **Bug** if someone reintroduced `run_band_frontend_after_gain` after AUTO. |
+| SMOKE in OrcSDR fails `gain_mode_auto_unsupported` | **Consumer bug** (stale assert). Fix OrcSDR. |
+| SDR# Bandwidth still not in driver | Not a bug. No EP0. |
+| Audio AGC in OrcSDR unchanged | Not this driver. |
+
+---
+
+## 7. Pass / fail for the Codex PR
+
+**Must**
+
+- [ ] Hygiene script OK at 0.7.8  
+- [ ] Host tests still pass (including `test_measured_agc_tables`)  
+- [ ] `p4_serial_smoke` still `idf.py build` for esp32p4 (CI)  
+- [ ] Smoke prints CAP_GAIN_AUTO / CAP_RTL_AGC  
+- [ ] With dongle, `gain_mode_auto` is PASS (`ESP_OK`)  
+- [ ] MANUAL set_gain still PASS  
+- [ ] No IF CAP invented  
+- [ ] PR description cites this handoff  
+
+**Should**
+
+- [ ] Serial CLI for human toggles  
+- [ ] Metrics logged before/after AUTO  
+- [ ] OrcSDR SMOKE inverted + CAPS bits (Phase B, separate PR if needed)  
+
+**Must not**
+
+- [ ] Paste librtlsdr  
+- [ ] Change MANUAL ladder bytes  
+- [ ] Mark Hardware-verified without `docs/lab/SOAK_*.md`  
+- [ ] Commit `esp_rtl_sdr.zip` or 100 MB pcaps  
+
+---
+
+## 8. Soak log (only path to Hardware-verified)
+
+Copy `docs/lab/SOAK_LOG_TEMPLATE.md` → `docs/lab/SOAK_P4_AGC_20260826.md` (use real date).
+
+Add rows:
+
+| Extra | Value |
+|---|---|
+| AUTO toggles | count / errors |
+| RTL AGC toggles | count / errors |
+| overrun delta during toggles | |
+| `read` after AUTO | bytes |
+
+Duration: 15 min is a **lab note**. ≥ 1 h continuous at 960k or 2.048M with periodic AUTO/MANUAL is the soak bar (`docs/SOAK.md`).
+
+---
+
+## 9. Files Codex is expected to touch (Phase A)
+
+| Path | Why |
+|---|---|
+| `examples/p4_serial_smoke/main/main.c` | AGC matrix ± CLI |
+| `examples/p4_serial_smoke/README.md` | How to read PASS/FAIL |
+| `examples/p4_serial_smoke/main/CMakeLists.txt` | Only if new sources |
+| `docs/TESTING_GUIDE.md` | Point at this handoff / new smoke rows |
+| `docs/lab/SOAK_*.md` | Only after a real run |
+
+Do **not** retouch `private/measured_gain_bias_v4.hpp` unless a lab recapture contradicts it (then stop and update PROJECT_TRUTH — that is a new capture, not this task).
+
+---
+
+## 10. Working directory cheat sheet
+
+```text
+Driver:     F:\Ai\ESP_RTL_SDR
+Smoke:      F:\Ai\ESP_RTL_SDR\examples\p4_serial_smoke
+OrcSDR:     F:\Ai\OrcSDR_Waveshare     (Phase B only)
+Lab pcaps:  C:\Tools\esp-rtl-sdr-lab\captures   (evidence; do not git-add)
+```
+
+Remote: https://github.com/hardcoreerik/esp-rtl-sdr  
+Default branch: **master** (there is no `main`).

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,8 @@ When docs disagree, PROJECT_TRUTH wins.
 | [AGC_IF_CAPTURE.md](AGC_IF_CAPTURE.md) | Tuner AUTO / RTL AGC / IF-filter USB capture |
 | [PHASE3_PC_SETUP.md](PHASE3_PC_SETUP.md) | Windows PC tool install / PATH / session recipe |
 | [HANDOFF_PHASE3_GAIN_BIAS.md](HANDOFF_PHASE3_GAIN_BIAS.md) | Full handoff + plan to finish issue #1 (gain/bias CAP) |
+| [HANDOFF_0_7_8_TEST.md](HANDOFF_0_7_8_TEST.md) | 0.7.8 AGC test plan + Codex prompt (smoke/OrcSDR/lab) |
+| [Test_reports/ESP_RTL_SDR_0_7_8_DROP_IN_TEST_REPORT_2026-08-26.md](Test_reports/ESP_RTL_SDR_0_7_8_DROP_IN_TEST_REPORT_2026-08-26.md) | Tab5 L4 matrix + false-REENTRANT / pull-ring findings |
 | [PHASE3_CAPTURE_REPORT.md](PHASE3_CAPTURE_REPORT.md) | Plain-English report: bias+gain lab captures and why they matter |
 | [TESTING.md](TESTING.md) | Lab gear (Heltec, Baofeng, Flipper, hosts) |
 | [PROFILES.md](PROFILES.md) | Dongle profiles |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -72,6 +72,7 @@ Truth of claims: [`../PROJECT_TRUTH.md`](../PROJECT_TRUTH.md).
 | `ERR_NOT_CLAIMED` | Call after successful `start` (interface must be claimed) |
 | `ERR_NOT_CLAIMED` on `set_tuner_gain_mode` / `set_rtl_agc` | Call after `start` (interface claimed) |
 | `ERR_REENTRANT` on gain/AGC | Do not call from the IQ event callback |
+| `get_tuner_gain` / `get_*_agc` disagrees with RF | Getters are **requested state**, not register readback. Setters are async while streaming. |
 | Gain/bias no RF/DC effect on P4 | P4 re-soak still open; PC capture tables may need re-verify on host |
 | Multimeter shows 0 V with bias ON | SMA DC not lab-certified yet; confirm EP0 path + supply |
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -71,7 +71,7 @@ Truth of claims: [`../PROJECT_TRUTH.md`](../PROJECT_TRUTH.md).
 |---|---|
 | `ERR_NOT_CLAIMED` | Call after successful `start` (interface must be claimed) |
 | `ERR_NOT_CLAIMED` on `set_tuner_gain_mode` / `set_rtl_agc` | Call after `start` (interface claimed) |
-| `ERR_REENTRANT` on gain/AGC | Do not call from the IQ event callback |
+| `ERR_REENTRANT` on gain/AGC | Only if **this task** is inside the event callback. App-task setters during IQ emit are allowed (fix after Tab5 L4). |
 | `get_tuner_gain` / `get_*_agc` disagrees with RF | Getters are **requested state**, not register readback. Setters are async while streaming. |
 | Gain/bias no RF/DC effect on P4 | P4 re-soak still open; PC capture tables may need re-verify on host |
 | Multimeter shows 0 V with bias ON | SMA DC not lab-certified yet; confirm EP0 path + supply |

--- a/docs/Test_reports/ESP_RTL_SDR_0_7_8_DROP_IN_TEST_REPORT_2026-08-26.md
+++ b/docs/Test_reports/ESP_RTL_SDR_0_7_8_DROP_IN_TEST_REPORT_2026-08-26.md
@@ -1,0 +1,286 @@
+# esp_rtl_sdr 0.7.8 Drop-In and Hardware Test Report
+
+Date: 2026-08-26  
+Repository: `https://github.com/hardcoreerik/esp-rtl-sdr.git`  
+Source branch/commit: `master` / `b74bbfe6fb278c8674490ba18f2495810a23128e`  
+Test branch: `codex/0-7-8-drop-in-tests`  
+Test worktree: `C:\Users\hardc\Documents\Codex\2026-08-26\lets-pause-for-a-bit\esp-rtl-sdr-0-7-8-tests`
+
+## Executive result
+
+The host, hygiene, ESP32-P4 build, flash, and attached RTL-SDR Blog V4 smoke
+layers were run. The final bounded hardware matrix passed:
+
+```text
+SMOKE OVERALL PASS passed=26 failed=0 hardware=RUN
+```
+
+The run proved that the 0.7.8 public contract is present, the Blog V4 streams
+IQ, manual gain remains usable, tuner AUTO and RTL AGC requests are accepted,
+IQ reads continue after transitions, and stop/uninstall succeed. USB overrun
+delta was zero.
+
+Testing also found one confirmed driver concurrency defect and one generic
+smoke configuration limit:
+
+1. `in_callback_depth` is handle-global, so a normal application-task setter
+   can incorrectly receive `ESP_RTL_SDR_ERR_REENTRANT` while another task is in
+   an event callback. The documented contract only forbids reentry from the
+   callback itself.
+2. The default auto-sized read ring could not allocate in the generic Tab5
+   smoke configuration, where external PSRAM was not enabled. Explicitly sizing
+   the ring to 64 KiB allowed the required reads to run. This is a drop-in
+   configuration risk, not proof that PSRAM-enabled consumers will fail.
+
+Current verdict: **L4 API/stream continuity passes with a bounded read ring;
+unconditional default-config drop-in acceptance does not pass because of the
+false-reentrancy defect and auto-ring allocation behavior.** L5 unchanged
+consumer testing and L6 soak remain open.
+
+## Scope and preservation
+
+The handoff was treated as the test specification. No measured EP0 tables,
+public API, driver implementation, consumer repository, or captured USB
+evidence was changed. The optional CLI was not added; the one-shot matrix is
+the smallest required test.
+
+The primary network checkout and all existing modified/untracked files were
+preserved. Implementation changes remain isolated in the test worktree. No
+commit, push, PR, merge, or branch deletion was performed.
+
+## Test implementation
+
+The smoke now emits grep-friendly rows:
+
+```text
+SMOKE <name> PASS|FAIL
+SMOKE OVERALL PASS|FAIL passed=<n> failed=<n> hardware=<state>
+```
+
+| Area | Live assertions |
+|---|---|
+| Contract | policy helpers and exact driver version 0.7.8 |
+| Capabilities | GAIN, GAIN_AUTO, RTL_AGC, BIAS_TEE |
+| Manual regression | 0, 297, and 400 -> 402; mode MANUAL |
+| Tuner AUTO | set/get shadow, idempotence, read, manual forcing, AUTO restore |
+| RTL AGC | on/off shadow, independence from tuner AUTO, read |
+| Restore | MANUAL mode, gain 297, read |
+| Runtime | metrics before/after, health, stop, uninstall |
+| No device | bounded enumeration wait; true NO_DEVICE remains a passing skip |
+
+The test callback ignores `EVT_IQ_BLOCK` logging so serial output cannot stall
+the delivery path. The read ring is explicitly 64 KiB because the smoke reads
+only at transition checkpoints and does not continuously drain IQ.
+
+Changed test files:
+
+- `examples/p4_serial_smoke/main/main.c`
+- `examples/p4_serial_smoke/README.md`
+- `examples/p4_serial_smoke/sdkconfig.defaults`
+- `docs/TESTING_GUIDE.md`
+
+The two sdkconfig defaults select the ESP32-P4 pre-v3 silicon family so the
+image is flashable on the Tab5's P4 revision 1.3.
+
+## Automated evidence
+
+### Host policy — PASS
+
+```text
+powershell -ExecutionPolicy Bypass -File tests\scripts\run_host_tests.ps1
+RESULT passed=219 failed=0
+HOST_TESTS_OK
+```
+
+### Truth/version hygiene — PASS
+
+```text
+tests/scripts/check_truth_hygiene.sh
+header version=0.7.8
+TRUTH_HYGIENE_OK ver=0.7.8
+```
+
+### Native ESP32-P4 build — PASS
+
+Environment: ESP-IDF 5.5.4, target `esp32p4`, pre-v3 P4 image family.
+
+```text
+idf.py build
+esp_rtl_sdr_p4_smoke.bin binary size 0x4fc40 bytes
+0xb03c0 bytes (69%) free
+```
+
+Final binary SHA-256:
+
+```text
+416F1A5A43EB2695F36EDDE2B0201615FC1AB0BBB8EAD1362118E7E5909D491D
+```
+
+The generated build directory was preserved and remains ignored.
+
+## Flash and boot evidence
+
+Port: `COM17`  
+Board: ESP32-P4 revision v1.3  
+Console/flash transport: USB Serial/JTAG  
+Attached receiver: RTLSDRBlog Blog V4, serial `00000001`, high-speed USB
+
+The first flash attempt safely stopped before writing because the initially
+generated image required P4 revision 3.1 or newer. After selecting the pre-v3
+family in `sdkconfig.defaults`, the rebuild and flash completed:
+
+```text
+Chip is ESP32-P4 (revision v1.3)
+Hash of data verified.
+Hard resetting via RTS pin...
+```
+
+Fresh boot then reported:
+
+```text
+ESP-IDF: v5.5.4-dirty
+Min chip rev: v0.1
+Max chip rev: v1.99
+Chip rev: v1.3
+install v0.7.8 caps=0x000fff3f xfer=6x16384
+open RTLSDRBlog Blog V4 serial=00000001 hs=1
+```
+
+The application `git describe` string printed `v0.7.7-1-gb74bbfe-dirty`; the
+driver's public version string and installed runtime both printed 0.7.8.
+
+## Hardware run 1: default-style stress — FAIL, useful bug evidence
+
+The first attached-device run used the default BOTH delivery mode, auto-sized
+pull ring, and logged every event. USB enumeration completed at about 560 ms,
+after the smoke had initially checked at about 160 ms. A bounded 3-second
+enumeration wait was added to the harness.
+
+With the device streaming, the run ended:
+
+```text
+SMOKE OVERALL FAIL passed=20 failed=6 hardware=RUN
+```
+
+Observed failures included:
+
+- IQ reads returning `ESP_ERR_NO_MEM` because the auto-sized pull ring could
+  not allocate in this generic configuration;
+- `manual_restore_mode` receiving `ESP_RTL_SDR_ERR_REENTRANT` from the app task
+  while delivery-task callbacks were active;
+- large consumer-drop counts caused by an undrained pull ring and synchronous
+  per-IQ serial logging.
+
+Despite those failures, IQ bytes continued increasing and USB overrun delta
+remained zero. This run is retained as negative drop-in evidence; it was not
+relabelled as a pass.
+
+## Hardware run 2: bounded matrix — PASS
+
+The rerun kept BOTH delivery semantics but suppressed raw IQ-event logging and
+used a 64 KiB pull ring. Device enumeration succeeded after the bounded wait.
+
+```text
+version_0_7_8                 PASS
+cap_gain                      PASS
+cap_gain_auto                 PASS
+cap_rtl_agc                   PASS
+cap_bias_tee                  PASS
+manual_gain_0                 PASS
+manual_gain_297               PASS
+manual_gain_400_nearest_402   PASS
+tuner_auto_set_get            PASS
+tuner_auto_idempotent         PASS
+tuner_auto_read               PASS, 4096 bytes
+gain_forces_manual            PASS
+tuner_auto_restore            PASS
+rtl_agc_on                    PASS
+rtl_agc_independent           PASS
+rtl_agc_off                   PASS
+rtl_agc_read                  PASS, 4096 bytes
+manual_restore_mode           PASS
+manual_restore_gain           PASS
+manual_restore_read           PASS, 4096 bytes
+metrics_after                 PASS
+health_after                  PASS
+stop                          PASS
+uninstall                     PASS
+SMOKE OVERALL PASS passed=26 failed=0 hardware=RUN
+```
+
+Rate passport:
+
+```text
+entries=9
+best_stable_sps=3200000
+```
+
+Final matrix metrics:
+
+```text
+before_bytes=2555904
+after_bytes=185779456
+overrun_delta=0
+consumer_drop_delta=16015360
+effective_sps=2935143
+last_error=ESP_OK
+health.efficiency=0.918
+health.overruns=0
+health.consumer_drops=18518016
+health.advice=app too slow
+```
+
+The consumer drops are expected from this intentionally small ring being read
+only three times during a multi-second 3.2 MS/s test. They do not indicate USB
+overruns; a continuously draining consumer is required for meaningful long-run
+consumer-drop acceptance.
+
+Repeated `USBH: Dev 1 EP 0 STALL` messages appeared during known device setup
+sequences but were nonfatal: each stream subsequently started and produced IQ.
+
+## Confirmed defect: false cross-task REENTRANT
+
+The public header says lifecycle/setter reentry is forbidden *from inside the
+callback*. The implementation checks only a handle-wide counter:
+
+```text
+if (h != nullptr && h->in_callback_depth > 0)
+    return ESP_RTL_SDR_ERR_REENTRANT;
+```
+
+Because it does not identify the callback task, an unrelated application task
+can be rejected during any concurrent callback. The first hardware run
+reproduced this on `set_tuner_gain_mode(MANUAL)`. This can affect existing
+default-BOTH consumers with event callbacks and is a real drop-in concurrency
+bug. No driver fix was made because this task was scoped to implementing and
+executing tests.
+
+## Evidence boundary
+
+While streaming, gain, tuner AUTO, RTL AGC, and bias setters queue EP0 work on
+the delivery task. `ESP_OK` means accepted. Getters report requested software
+shadow state, not physical register readback.
+
+This report may claim API contract, CAP bits, IQ continuity, metrics, and health
+around requests. It does **not** claim that the P4 read back R828D `05=E8`, tuner
+`07=78`/`0C=6B`, or demod `0x19=0x25`. Physical register evidence remains the PC
+USBPcap. Matching getters are not a substitute for that capture.
+
+## Remaining gaps
+
+| Evidence layer | Status |
+|---|---|
+| L0 hygiene | PASS |
+| L1 host policy | PASS, 219/219 |
+| L2 P4 compile/link | PASS, ESP-IDF 5.5.4 |
+| Flash/boot | PASS, Tab5 P4 v1.3 |
+| L3 physical no-dongle run | NOT RUN; initial zero count was enumeration timing, not absence |
+| L4 Blog V4 matrix | PASS with 64 KiB ring; default-style stress FAIL retained |
+| Physical register readback | NOT RUN; PC USBPcap remains separate evidence |
+| L5 unchanged consumer | NOT RUN; Phase B was not authorized |
+| L6 15-minute/1-hour soak | NOT RUN |
+
+No claim of full hardware verification, production stability, or unchanged
+consumer drop-in compatibility should be made until the cross-task reentrancy
+bug is fixed, an unchanged consumer is exercised, and a continuously drained
+soak log is completed.

--- a/include/esp_rtl_sdr.h
+++ b/include/esp_rtl_sdr.h
@@ -856,24 +856,33 @@ typedef enum {
 
 /**
  * Set tuner gain mode. Requires claimed interface (after start).
- * AUTO writes measured 05/07/0c AGC ON (CAP_GAIN_AUTO). MANUAL restores the
+ * AUTO queues measured 05/07/0c AGC ON (CAP_GAIN_AUTO). MANUAL restores the
  * last ladder step (or 0.0 dB if never set). Same mode twice is a no-op.
+ * While streaming, EP0 runs on the delivery task after a bulk pause (async).
+ * ESP_OK means the request was accepted, not that the dongle ACKed registers.
  * set_tuner_gain() forces MANUAL. Not the RTL digital AGC (see set_rtl_agc).
  */
 esp_err_t esp_rtl_sdr_set_tuner_gain_mode(esp_rtl_sdr_handle_t handle,
                                           esp_rtl_sdr_gain_mode_t mode);
 
-/** Get last requested gain mode (default AUTO). */
+/**
+ * Last **requested** gain mode (default AUTO). Not a tuner register readback.
+ * May read AUTO before any AUTO EP0 has been sent (preference only).
+ */
 esp_err_t esp_rtl_sdr_get_tuner_gain_mode(esp_rtl_sdr_handle_t handle,
                                           esp_rtl_sdr_gain_mode_t *out_mode);
 
 /**
  * Manual gain in tenths of dB (e.g. 496 = 49.6 dB). Applies nearest measured
  * Blog V4 step (0.0…49.6 dB ladder). Requires claimed interface (after start).
+ * Streaming: queued on the delivery task (async). ESP_OK = accepted request.
  */
 esp_err_t esp_rtl_sdr_set_tuner_gain(esp_rtl_sdr_handle_t handle, int gain_tenth_db);
 
-/** Last applied / requested manual gain (tenths dB); 0 if never set. */
+/**
+ * Last requested / last accepted ladder step (tenths dB); 0 if never set.
+ * Software shadow — not an I2C/EP0 read of R828D registers.
+ */
 esp_err_t esp_rtl_sdr_get_tuner_gain(esp_rtl_sdr_handle_t handle, int *out_gain_tenth_db);
 
 /**
@@ -886,6 +895,7 @@ esp_err_t esp_rtl_sdr_get_tuner_gains(esp_rtl_sdr_handle_t handle, int *out_gain
 /**
  * Bias-T enable via measured Blog V4 SYS EP0 (lab 2026-08-12).
  * Requires claimed interface (after start). Multimeter DC not yet recorded.
+ * Streaming: async sideband queue. get_bias_tee() is last requested preference.
  */
 esp_err_t esp_rtl_sdr_set_bias_tee(esp_rtl_sdr_handle_t handle, bool enable);
 esp_err_t esp_rtl_sdr_get_bias_tee(esp_rtl_sdr_handle_t handle, bool *out_enable);
@@ -893,7 +903,8 @@ esp_err_t esp_rtl_sdr_get_bias_tee(esp_rtl_sdr_handle_t handle, bool *out_enable
 /**
  * RTL2832 digital AGC (SDR# "RTL AGC") — measured demod 0x19 ON=0x25 OFF=0x05.
  * Requires CAP_RTL_AGC and a claimed interface. Independent of tuner AUTO.
- * Additive 0.7.8; default off. Same reentrancy / async sideband rules as gain.
+ * Additive 0.7.8; default off. Same async sideband rules as gain.
+ * set: ESP_OK = request accepted. get: last requested shadow, not demod readback.
  */
 esp_err_t esp_rtl_sdr_set_rtl_agc(esp_rtl_sdr_handle_t handle, bool enable);
 esp_err_t esp_rtl_sdr_get_rtl_agc(esp_rtl_sdr_handle_t handle, bool *out_enable);

--- a/include/esp_rtl_sdr.h
+++ b/include/esp_rtl_sdr.h
@@ -47,8 +47,10 @@
  * - Safe: concurrent get_state / get_metrics / get_device_info / get_last_error
  *   from any task with a live handle.
  * - Safe: start / stop / retune / reset from app tasks (serialized).
- * - Forbidden: install/uninstall/start/stop/retune/reset from inside the
- *   event callback on the same handle (ERR_REENTRANT).
+ * - Forbidden: install/uninstall/start/stop/retune/reset **from the event
+ *   callback task** on the same handle (ERR_REENTRANT). Other tasks may call
+ *   setters while a callback is running; the guard is the calling task, not a
+ *   handle-global "callback in progress" flag.
  * - Forbidden: any public API from a USB completion ISR.
  * - IQ / events: delivered from the driver USB owner task (or a dedicated
  *   delivery task). Callbacks must return quickly (no display paint, flash,

--- a/private/reentrancy.hpp
+++ b/private/reentrancy.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cstdint>
+
+/**
+ * True only when *this caller* is inside the handle's event callback.
+ * A handle-wide depth counter is not enough: the delivery task can be in
+ * emit() while an application task calls set_tuner_gain_mode().
+ */
+inline bool esp_rtl_sdr_caller_is_event_callback(uint32_t callback_depth,
+                                                 const void *callback_task,
+                                                 const void *self_task)
+{
+    return callback_depth > 0 && callback_task != nullptr && self_task != nullptr &&
+           callback_task == self_task;
+}

--- a/src/esp_rtl_sdr.cpp
+++ b/src/esp_rtl_sdr.cpp
@@ -31,6 +31,7 @@
 
 #include "transfers_blog_v4.hpp"
 #include "measured_gain_bias_v4.hpp"
+#include "reentrancy.hpp"
 
 static const char *TAG = "esp_rtl_sdr";
 
@@ -86,6 +87,8 @@ struct esp_rtl_sdr_handle {
     uint32_t sample_rate_sps = 0;
     uint32_t stream_start_ms = 0;
     uint32_t in_callback_depth = 0;
+    /** Task currently inside emit_after_unlock; null if depth == 0. */
+    TaskHandle_t callback_task = nullptr;
     bool destroying = false;
 
     bool owns_host = false;
@@ -242,7 +245,12 @@ static void set_error_unlocked(esp_rtl_sdr_handle *h, esp_err_t err)
 
 static esp_err_t check_not_reentrant(const esp_rtl_sdr_handle *h)
 {
-    if (h != nullptr && h->in_callback_depth > 0) {
+    if (h == nullptr) {
+        return ESP_OK;
+    }
+    const uint32_t depth = __atomic_load_n(&h->in_callback_depth, __ATOMIC_SEQ_CST);
+    const TaskHandle_t cb = __atomic_load_n(&h->callback_task, __ATOMIC_SEQ_CST);
+    if (esp_rtl_sdr_caller_is_event_callback(depth, cb, xTaskGetCurrentTaskHandle())) {
         return ESP_RTL_SDR_ERR_REENTRANT;
     }
     return ESP_OK;
@@ -256,9 +264,8 @@ static uint32_t now_ms(void)
 
 /**
  * Invoke app callback without holding the API mutex.
- * Uses atomic in_callback_depth so reentrancy guards work even if emit is
- * nested under another caller's lock (which must not happen — callers should
- * release first; select_device defers emit until after unlock).
+ * Depth + callback_task are atomic so another task can call setters while
+ * we emit; only the callback task itself is ERR_REENTRANT.
  */
 static void emit_after_unlock(esp_rtl_sdr_handle *h,
                               esp_rtl_sdr_event_t ev,
@@ -269,14 +276,17 @@ static void emit_after_unlock(esp_rtl_sdr_handle *h,
     if (cb == nullptr || h == nullptr) {
         return;
     }
+    const TaskHandle_t self = xTaskGetCurrentTaskHandle();
     if (handle_live(h)) {
+        __atomic_store_n(&h->callback_task, self, __ATOMIC_SEQ_CST);
         __atomic_add_fetch(&h->in_callback_depth, 1u, __ATOMIC_SEQ_CST);
     }
     cb(ev, payload, ctx);
     if (handle_live(h)) {
-        uint32_t d = __atomic_load_n(&h->in_callback_depth, __ATOMIC_SEQ_CST);
-        if (d > 0) {
-            __atomic_sub_fetch(&h->in_callback_depth, 1u, __ATOMIC_SEQ_CST);
+        const uint32_t d = __atomic_sub_fetch(&h->in_callback_depth, 1u, __ATOMIC_SEQ_CST);
+        if (d == 0) {
+            __atomic_store_n(&h->callback_task, static_cast<TaskHandle_t>(nullptr),
+                             __ATOMIC_SEQ_CST);
         }
     }
 }
@@ -1627,7 +1637,9 @@ esp_err_t esp_rtl_sdr_uninstall(esp_rtl_sdr_handle_t handle)
         if (handle->destroying) {
             return ESP_RTL_SDR_ERR_BUSY;
         }
-        if (handle->in_callback_depth > 0) {
+        const uint32_t depth = __atomic_load_n(&handle->in_callback_depth, __ATOMIC_SEQ_CST);
+        const TaskHandle_t cb = __atomic_load_n(&handle->callback_task, __ATOMIC_SEQ_CST);
+        if (esp_rtl_sdr_caller_is_event_callback(depth, cb, xTaskGetCurrentTaskHandle())) {
             return ESP_RTL_SDR_ERR_REENTRANT;
         }
         handle->destroying = true;
@@ -2048,7 +2060,12 @@ esp_err_t esp_rtl_sdr_retune_hz(esp_rtl_sdr_handle_t handle, uint32_t frequency_
             return ESP_RTL_SDR_ERR_NOT_STREAMING;
         }
         handle->pending_retune_hz = q;
-        from_callback = (handle->in_callback_depth > 0);
+        {
+            const uint32_t depth = __atomic_load_n(&handle->in_callback_depth, __ATOMIC_SEQ_CST);
+            const TaskHandle_t cb = __atomic_load_n(&handle->callback_task, __ATOMIC_SEQ_CST);
+            from_callback =
+                esp_rtl_sdr_caller_is_event_callback(depth, cb, xTaskGetCurrentTaskHandle());
+        }
         set_error_unlocked(handle, ESP_OK);
     }
 

--- a/tests/host/test_policy.cpp
+++ b/tests/host/test_policy.cpp
@@ -12,6 +12,7 @@
 
 #include "esp_rtl_sdr.h"
 #include "measured_gain_bias_v4.hpp"
+#include "reentrancy.hpp"
 
 static int g_failed = 0;
 static int g_passed = 0;
@@ -155,6 +156,21 @@ static void test_measured_agc_tables(void)
     EXPECT_EQ_U(dem.index, 0x0010);
     EXPECT_EQ_U(dem.length, 1);
     EXPECT_EQ_U(dem.data[0], 0x25);
+}
+
+static void test_callback_reentry_is_task_local(void)
+{
+    const void *delivery = reinterpret_cast<const void *>(0x1000);
+    const void *app = reinterpret_cast<const void *>(0x2000);
+
+    EXPECT_TRUE(!esp_rtl_sdr_caller_is_event_callback(0, delivery, app));
+    EXPECT_TRUE(!esp_rtl_sdr_caller_is_event_callback(1, nullptr, app));
+    EXPECT_TRUE(!esp_rtl_sdr_caller_is_event_callback(1, delivery, nullptr));
+    /* Delivery task emitting: app task is NOT reentrant. */
+    EXPECT_TRUE(!esp_rtl_sdr_caller_is_event_callback(1, delivery, app));
+    /* Callback task calling a setter: IS reentrant. */
+    EXPECT_TRUE(esp_rtl_sdr_caller_is_event_callback(1, delivery, delivery));
+    EXPECT_TRUE(esp_rtl_sdr_caller_is_event_callback(2, app, app));
 }
 
 static void test_rate_windows(void)
@@ -515,6 +531,7 @@ int main(void)
     test_version();
     test_capabilities();
     test_measured_agc_tables();
+    test_callback_reentry_is_task_local();
     test_delivery_mode_helpers();
     test_rate_windows();
     test_recommended_rates();


### PR DESCRIPTION
## Bookmark (this is the 0.7.8 save point)

PRs here are chapter markers: **save what we know, then move forward.**

This PR **includes 0.7.8**. The branch tip is `b6b053d` on top of **`b74bbfe` / PR #7** (`feat(0.7.8): measured Tuner AGC AUTO and RTL digital AGC`). GitHub’s Files tab only diffs *new* commits vs current `master`, so #7’s EP0 tables do not reappear as a patch — they are already the parent. Merging #8 is the close of the 0.7.8 chapter on `master`.

### Already on master (PR #7) — this chapter’s feature

- **`CAP_GAIN_AUTO`**: `set_tuner_gain_mode(AUTO)` → measured IR `05=E8 07=78 0C=6B`
- **`CAP_RTL_AGC`**: additive `set/get_rtl_agc` → demod `0x19` ON=`0x25` OFF=`0x05`
- MANUAL ladder / bias-T unchanged (drop-in)
- No IF-filter CAP (SDR# Bandwidth USB-silent)
- Live setters **async**; getters are **software shadow**, not R828D readback

### This PR adds (close the bookmark)

1. Tab5 L4 report: `docs/Test_reports/ESP_RTL_SDR_0_7_8_DROP_IN_TEST_REPORT_2026-08-26.md`  
   Bounded matrix **26/26 PASS**, USB overrun delta 0. Default-style stress FAIL retained (false REENTRANT + auto-ring `NO_MEM`).
2. **Fix:** `ERR_REENTRANT` is the **callback task**, not a handle-global depth flag. App-task gain/mode setters may run while `EVT_IQ_BLOCK` emits.
3. Handoff + API honesty for the evidence bound.

### Not this bookmark

- Auto pull-ring `NO_MEM` on generic Tab5 (config; 64 KiB workaround in Codex smoke)
- L5 OrcSDR consumer / L6 soak
- Hardware-verified EP0 on P4 (USBPcap remains the latch evidence)

Merge = 0.7.8 driver + L4 report + reentrancy fix on `master`. Then next work.