### PR TITLE
release(0.7.9): Tab5 auto-ring shrink and default smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,25 @@
 
 ## Unreleased
 
+## 0.7.9 (2026-08-26)
+
 ### Fixed
 
+- **Auto pull-ring `ESP_ERR_NO_MEM` on no-PSRAM Tab5:** default `pull_ring_bytes=0`
+  still prefers ~4× URB (min ~192 KiB). If PSRAM/internal cannot allocate that,
+  auto size now shrinks to the largest even internal block down to 64 KiB.
+  Explicit `pull_ring_bytes` stays fail-closed. Tab5 L4 run 1 in
+  `docs/Test_reports/ESP_RTL_SDR_0_7_8_DROP_IN_TEST_REPORT_2026-08-26.md`.
 - **False `ERR_REENTRANT`:** reentrancy is the **callback task**, not a handle-wide
-  depth flag. App-task `set_tuner_gain_mode` / gain / bias / RTL AGC no longer fail
-  while the delivery task is emitting `EVT_IQ_BLOCK`. Tab5 L4 run 1 reproduced this
-  (`docs/Test_reports/ESP_RTL_SDR_0_7_8_DROP_IN_TEST_REPORT_2026-08-26.md`).
-  `retune_hz` async-from-callback uses the same task check.
+  depth flag. App-task setters no longer fail while the delivery task is emitting
+  `EVT_IQ_BLOCK`. (Landed on 0.7.8 `master` untagged; first immutable tag is 0.7.9.)
+
+### Smoke
+
+- `examples/p4_serial_smoke` keeps real default auto ring (no 64 KiB override),
+  suppresses IQ event logging, waits 3 s for enumeration, and emits L4 AUTO/RTL
+  AGC rows. `sdkconfig.defaults` selects pre-v3 P4 silicon for Tab5 rev v1.3.
+  Hardware re-run on COM17 is still required.
 
 ## 0.7.8 (2026-08-26)
 

--- a/PROJECT_TRUTH.md
+++ b/PROJECT_TRUTH.md
@@ -7,7 +7,7 @@ Same discipline as [TheOrc PROJECT_TRUTH](https://github.com/hardcoreerik/TheOrc
 claims need evidence labels; oversell is a bug; retract rather than spin.
 
 Snapshot date: **2026-08-26**  
-Version: **0.7.8** (measured Tuner AUTO + RTL AGC — not production-ready)  
+Version: **0.7.9** (Tab5 auto-ring drop-in shrink; Tuner AUTO + RTL AGC — not production-ready)  
 Local repo: `F:\Ai\ESP_RTL_SDR\`  
 Remote: **https://github.com/hardcoreerik/esp-rtl-sdr**  
 Open-source honesty: [docs/AI_DEVELOPMENT_DISCLOSURE.md](docs/AI_DEVELOPMENT_DISCLOSURE.md) ·
@@ -118,6 +118,7 @@ Product vision: **`docs/VISION.md`**. Silicon / DS map: **`docs/SILICON.md`**.
 | **0.7.6** | Async mid-stream gain/bias (bulk-pause queue); stall retries; desktop-gap map |
 | **0.7.7** | HF upconverter CAP (RF+28.8e6) |
 | **0.7.8** | Measured Tuner AUTO + RTL digital AGC; IF filter USB-silent |
+| **0.7.9** | Auto pull-ring shrink for no-PSRAM Tab5; task-local REENTRANT |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Make an RTL-SDR Blog V4 a first-class peripheral on ESP32-P4** — continuous I/Q over USB Host, with a real embedded driver API.
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
-![Status](https://img.shields.io/badge/version-0.7.8-green)
+![Status](https://img.shields.io/badge/version-0.7.9-green)
 [![GitHub](https://img.shields.io/badge/github-esp--rtl--sdr-black)](https://github.com/hardcoreerik/esp-rtl-sdr)
 ![Target](https://img.shields.io/badge/ESP32--P4-HS_USB-green)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,7 +1,7 @@
 # esp_rtl_sdr public API — design contract
 
 **Header:** [`include/esp_rtl_sdr.h`](../include/esp_rtl_sdr.h)  
-**Version:** 0.7.8  
+**Version:** 0.7.9  
 **Full parameter / return / example reference:** [`API_REFERENCE.md`](API_REFERENCE.md)
 
 This document is the **design contract** (invariants, threading, ABI growth).  

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # esp_rtl_sdr — API Reference
 
-> **Version tracked:** `0.7.8` (see `ESP_RTL_SDR_VERSION_*` in [`include/esp_rtl_sdr.h`](../include/esp_rtl_sdr.h))  
+> **Version tracked:** `0.7.9` (see `ESP_RTL_SDR_VERSION_*` in [`include/esp_rtl_sdr.h`](../include/esp_rtl_sdr.h))  
 > **Header of record:** [`include/esp_rtl_sdr.h`](../include/esp_rtl_sdr.h)  
 > **Design contract (invariants, ABI growth):** [`API.md`](API.md)  
 > **What works on hardware right now:** [`../PROJECT_TRUTH.md`](../PROJECT_TRUTH.md) wins on any claim conflict.

--- a/docs/RUNTIME_CONSTANTS.md
+++ b/docs/RUNTIME_CONSTANTS.md
@@ -21,11 +21,13 @@ and how apps can influence them.
 |---|---|
 | When allocated | First IQ push or first `read()` if `delivery_mode` is BOTH or READ |
 | Never allocated | `DELIVERY_CALLBACK` |
-| Default size | ~4× URB total, min ~192 KiB, max 512 KiB |
-| Override | `config.pull_ring_bytes` (even, 1 KiB…1 MiB) |
+| Default size | Auto: prefer ~4× URB total, min ~192 KiB, max 512 KiB. If that malloc fails (no PSRAM / small internal heap), shrink to the largest even internal block down to **64 KiB**. |
+| Override | `config.pull_ring_bytes` (even, 1 KiB…1 MiB). Exact size; `ESP_ERR_NO_MEM` if it cannot allocate (no shrink). |
+
+**Why shrink:** Tab5 generic smoke (P4 v1.3, PSRAM off) could not allocate 192 KiB and failed IQ `read()` with `ESP_ERR_NO_MEM`. 64 KiB was the proven floor. Auto drop-in must not require a consumer override.
 
 **App control:** Prefer `DELIVERY_CALLBACK` if you never call `read()` (saves RAM).
-Tune URB geometry via [`KCONFIG.md`](KCONFIG.md); watch `consumer_drops`.
+Tune URB geometry via [`KCONFIG.md`](KCONFIG.md); watch `consumer_drops`. A shrunk ring still streams; a slow consumer shows up as `consumer_drops` / `app too slow`, not USB overruns.
 
 ---
 

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -96,9 +96,16 @@ examples/p4_serial_smoke + EXTRA_COMPONENT_DIRS → this repo
 
 | Result | Meaning |
 |---|---|
-| Helpers pass, start → NO_DEVICE | Policy OK; no dongle |
-| start → OK, read bytes > 0 | Stream path alive |
-| `probe_rates` entries / best_stable | Passport learned on **this** host |
+| Helpers pass, start → NO_DEVICE | Policy OK; no dongle (`hardware=SKIP`) |
+| `SMOKE default_auto_ring PASS` | Smoke did not override `pull_ring_bytes` |
+| start → OK, `first_read` bytes > 0 | Default auto ring allocated (no 64 KiB workaround) |
+| Tuner AUTO / RTL AGC / manual ladder rows | 0.7.8 sideband contract |
+| `SMOKE OVERALL PASS hardware=RUN` | Bounded L4 matrix on attached Blog V4 |
+
+Do **not** set `cfg.pull_ring_bytes` in this smoke. Serial must not log `EVT_IQ_BLOCK`.
+`sdkconfig.defaults` must keep pre-v3 P4 (`CONFIG_ESP32P4_REV_MIN_0`) for Tab5 rev v1.3.
+
+L5 unchanged-consumer (OrcSDR) and L6 soak remain open. Re-run this smoke on Tab5 COM17 after the auto-ring shrink before claiming hardware-verified drop-in.
 
 Log outcomes into PROJECT_TRUTH only with evidence labels (Hardware-verified vs Provenance).
 

--- a/examples/p4_serial_smoke/README.md
+++ b/examples/p4_serial_smoke/README.md
@@ -1,7 +1,23 @@
 # p4_serial_smoke
 
-Minimal ESP-IDF app that links **esp_rtl_sdr** and exercises the public API
-(helpers, install/start/read, need/health/passport when a Blog V4 is present).
+ESP-IDF app that links **esp_rtl_sdr** and exercises the public 0.7.9 drop-in
+contract on ESP32-P4 / Tab5.
+
+Default install only: `delivery_mode` BOTH, `pull_ring_bytes` 0 (auto). The
+driver must shrink the auto ring if PSRAM is missing; this app must **not**
+hardcode 64 KiB.
+
+IQ `EVT_IQ_BLOCK` logging is suppressed so serial cannot stall delivery.
+
+## Rows
+
+```text
+SMOKE <name> PASS|FAIL
+SMOKE OVERALL PASS|FAIL passed=<n> failed=<n> hardware=RUN|SKIP
+```
+
+No dongle: helpers + install/uninstall still pass (`hardware=SKIP`).
+Attached Blog V4: L4 gain / tuner AUTO / RTL AGC / read matrix (`hardware=RUN`).
 
 ## Build (ESP32-P4)
 
@@ -13,6 +29,8 @@ idf.py build
 # optional: idf.py -p COMx flash monitor
 ```
 
+`sdkconfig.defaults` selects pre-v3 P4 silicon so a Tab5 rev v1.3 can flash.
+
 The component is pulled via `components/esp_rtl_sdr/` (stable name wrapping the
 repo root sources). No dongle is required for a successful **compile**.
 
@@ -20,3 +38,5 @@ repo root sources). No dongle is required for a successful **compile**.
 
 GitHub Actions job `idf-p4-build` only compiles (no hardware). Lab soak remains
 manual — see `docs/LAB_HOBBYIST.md` and `docs/TESTING_GUIDE.md`.
+
+L5 unchanged-consumer (OrcSDR) and L6 soak remain open.

--- a/examples/p4_serial_smoke/main/main.c
+++ b/examples/p4_serial_smoke/main/main.c
@@ -1,7 +1,13 @@
 /*
- * Minimal ESP-IDF smoke for esp_rtl_sdr public API contract (v0.7).
+ * ESP-IDF Tab5 / P4 drop-in smoke for esp_rtl_sdr public API (v0.7.9).
  *
- * Build with EXTRA_COMPONENT_DIRS pointing at the esp_rtl_sdr repo root.
+ * Default config only: delivery BOTH, pull_ring_bytes = 0 (auto). The driver
+ * must allocate on no-PSRAM Tab5-class heaps; do not hardcode 64 KiB here.
+ * IQ event logging is suppressed so serial cannot stall the delivery path.
+ *
+ * Grep-friendly rows:
+ *   SMOKE <name> PASS|FAIL
+ *   SMOKE OVERALL PASS|FAIL passed=<n> failed=<n> hardware=<RUN|SKIP>
  */
 #include <stdio.h>
 #include <string.h>
@@ -14,60 +20,158 @@
 
 static const char *TAG = "esp_rtl_sdr_smoke";
 
+static int g_pass;
+static int g_fail;
+
+static void smoke_row(const char *name, bool ok)
+{
+    if (ok) {
+        g_pass++;
+        printf("SMOKE %s PASS\n", name);
+    } else {
+        g_fail++;
+        printf("SMOKE %s FAIL\n", name);
+        ESP_LOGE(TAG, "FAIL %s", name);
+    }
+}
+
 static void on_event(esp_rtl_sdr_event_t event, const void *payload, void *ctx)
 {
     (void)ctx;
+    if (event == ESP_RTL_SDR_EVT_IQ_BLOCK) {
+        return; /* never log IQ; serial stalls the delivery path */
+    }
     if (event == ESP_RTL_SDR_EVT_PASSPORT_PROGRESS && payload != NULL) {
         const esp_rtl_sdr_passport_entry_t *e = payload;
         ESP_LOGI(TAG, "passport progress rate=%u eff=%u stable=%d",
                  (unsigned)e->exact_sps, (unsigned)e->effective_sps, (int)e->stable);
         return;
     }
-    ESP_LOGI(TAG, "event=%d", (int)event);
+}
+
+static void settle_ms(int ms)
+{
+    vTaskDelay(pdMS_TO_TICKS(ms));
+}
+
+static bool smoke_read(esp_rtl_sdr_handle_t sdr, const char *name)
+{
+    uint8_t iq[4096];
+    size_t n = 0;
+    const esp_err_t err = esp_rtl_sdr_read(sdr, iq, sizeof(iq), 1000, &n);
+    const bool ok = (err == ESP_OK && n == sizeof(iq));
+    smoke_row(name, ok);
+    ESP_LOGI(TAG, "%s -> %s bytes=%u", name, esp_rtl_sdr_err_to_name(err), (unsigned)n);
+    return ok;
+}
+
+static size_t wait_devices(esp_rtl_sdr_handle_t sdr, int timeout_ms)
+{
+    size_t count = 0;
+    int waited = 0;
+    do {
+        (void)esp_rtl_sdr_refresh_device_list(sdr);
+        (void)esp_rtl_sdr_get_device_count(sdr, &count);
+        if (count > 0) {
+            return count;
+        }
+        settle_ms(200);
+        waited += 200;
+    } while (waited < timeout_ms);
+    return 0;
 }
 
 static void check_pure_helpers(void)
 {
     uint32_t q = 0;
-    if (!esp_rtl_sdr_normalize_frequency(96123456, &q) || q != 96123000) {
-        ESP_LOGE(TAG, "normalize_frequency failed");
-    }
+    smoke_row("normalize_frequency",
+              esp_rtl_sdr_normalize_frequency(96123456, &q) && q == 96123000);
 
     uint32_t exact = 0;
-    if (!esp_rtl_sdr_quantize_sample_rate(2048000, &exact) || exact == 0) {
-        ESP_LOGE(TAG, "quantize 2048k failed");
-    }
-    if (!esp_rtl_sdr_is_rate_supported(1536000)) {
-        ESP_LOGE(TAG, "1536k continuous should be supported");
-    }
-    if (esp_rtl_sdr_is_rate_supported(500000)) {
-        ESP_LOGE(TAG, "500k gap band must be rejected");
-    }
-    if (esp_rtl_sdr_is_rate_supported(4000000)) {
-        ESP_LOGE(TAG, "4M above max must be rejected");
-    }
+    smoke_row("quantize_2048k",
+              esp_rtl_sdr_quantize_sample_rate(2048000, &exact) && exact != 0);
+    smoke_row("rate_1536k_ok", esp_rtl_sdr_is_rate_supported(1536000));
+    smoke_row("rate_500k_reject", !esp_rtl_sdr_is_rate_supported(500000));
+    smoke_row("rate_4M_reject", !esp_rtl_sdr_is_rate_supported(4000000));
 
-    size_t n = 0;
-    ESP_ERROR_CHECK(esp_rtl_sdr_get_supported_rates(NULL, 0, &n));
-    uint32_t rates[16];
-    size_t written = 0;
-    if (n > sizeof(rates) / sizeof(rates[0])) {
-        n = sizeof(rates) / sizeof(rates[0]);
-    }
-    ESP_ERROR_CHECK(esp_rtl_sdr_get_supported_rates(rates, n, &written));
+    const char *ver = esp_rtl_sdr_get_version_string();
+    smoke_row("version_0_7_9", ver != NULL && strcmp(ver, "0.7.9") == 0);
 
     const uint32_t caps = esp_rtl_sdr_get_capabilities();
-    const uint32_t need =
-        ESP_RTL_SDR_CAP_CONTINUOUS_RATE | ESP_RTL_SDR_CAP_NEED | ESP_RTL_SDR_CAP_HEALTH |
-        ESP_RTL_SDR_CAP_PASSPORT | ESP_RTL_SDR_CAP_SYNC_READ;
-    if ((caps & need) != need) {
-        ESP_LOGE(TAG, "missing 0.7 caps got=0x%08x need=0x%08x", (unsigned)caps,
-                 (unsigned)need);
-    }
+    smoke_row("cap_gain", (caps & ESP_RTL_SDR_CAP_GAIN) != 0);
+    smoke_row("cap_gain_auto", (caps & ESP_RTL_SDR_CAP_GAIN_AUTO) != 0);
+    smoke_row("cap_rtl_agc", (caps & ESP_RTL_SDR_CAP_RTL_AGC) != 0);
+    smoke_row("cap_bias_tee", (caps & ESP_RTL_SDR_CAP_BIAS_TEE) != 0);
+    smoke_row("cap_sync_read", (caps & ESP_RTL_SDR_CAP_SYNC_READ) != 0);
 
-    ESP_LOGI(TAG, "helpers ok rates=%u exact2048=%u version=%s caps=0x%08x",
-             (unsigned)written, (unsigned)exact, esp_rtl_sdr_get_version_string(),
-             (unsigned)caps);
+    ESP_LOGI(TAG, "helpers version=%s caps=0x%08x", ver, (unsigned)caps);
+}
+
+static void run_l4_matrix(esp_rtl_sdr_handle_t sdr)
+{
+    esp_err_t err;
+    int gain = -1;
+    esp_rtl_sdr_gain_mode_t mode = ESP_RTL_SDR_GAIN_MODE_MANUAL;
+    bool rtl = true;
+
+    err = esp_rtl_sdr_set_tuner_gain(sdr, 0);
+    settle_ms(250);
+    (void)esp_rtl_sdr_get_tuner_gain(sdr, &gain);
+    smoke_row("manual_gain_0", err == ESP_OK && gain == 0);
+    smoke_read(sdr, "manual_gain_0_read");
+
+    err = esp_rtl_sdr_set_tuner_gain(sdr, 297);
+    settle_ms(250);
+    (void)esp_rtl_sdr_get_tuner_gain(sdr, &gain);
+    smoke_row("manual_gain_297", err == ESP_OK && gain == 297);
+
+    err = esp_rtl_sdr_set_tuner_gain(sdr, 400);
+    settle_ms(250);
+    (void)esp_rtl_sdr_get_tuner_gain(sdr, &gain);
+    smoke_row("manual_gain_400_nearest_402", err == ESP_OK && gain == 402);
+
+    err = esp_rtl_sdr_set_tuner_gain_mode(sdr, ESP_RTL_SDR_GAIN_MODE_AUTO);
+    settle_ms(250);
+    (void)esp_rtl_sdr_get_tuner_gain_mode(sdr, &mode);
+    smoke_row("tuner_auto_set_get", err == ESP_OK && mode == ESP_RTL_SDR_GAIN_MODE_AUTO);
+
+    err = esp_rtl_sdr_set_tuner_gain_mode(sdr, ESP_RTL_SDR_GAIN_MODE_AUTO);
+    smoke_row("tuner_auto_idempotent", err == ESP_OK);
+    smoke_read(sdr, "tuner_auto_read");
+
+    err = esp_rtl_sdr_set_tuner_gain(sdr, 297);
+    settle_ms(250);
+    (void)esp_rtl_sdr_get_tuner_gain_mode(sdr, &mode);
+    smoke_row("gain_forces_manual", err == ESP_OK && mode == ESP_RTL_SDR_GAIN_MODE_MANUAL);
+
+    err = esp_rtl_sdr_set_tuner_gain_mode(sdr, ESP_RTL_SDR_GAIN_MODE_AUTO);
+    settle_ms(250);
+    (void)esp_rtl_sdr_get_tuner_gain_mode(sdr, &mode);
+    smoke_row("tuner_auto_restore", err == ESP_OK && mode == ESP_RTL_SDR_GAIN_MODE_AUTO);
+
+    err = esp_rtl_sdr_set_rtl_agc(sdr, true);
+    settle_ms(250);
+    (void)esp_rtl_sdr_get_rtl_agc(sdr, &rtl);
+    (void)esp_rtl_sdr_get_tuner_gain_mode(sdr, &mode);
+    smoke_row("rtl_agc_on", err == ESP_OK && rtl);
+    smoke_row("rtl_agc_independent", mode == ESP_RTL_SDR_GAIN_MODE_AUTO);
+
+    err = esp_rtl_sdr_set_rtl_agc(sdr, false);
+    settle_ms(250);
+    (void)esp_rtl_sdr_get_rtl_agc(sdr, &rtl);
+    smoke_row("rtl_agc_off", err == ESP_OK && !rtl);
+    smoke_read(sdr, "rtl_agc_read");
+
+    err = esp_rtl_sdr_set_tuner_gain_mode(sdr, ESP_RTL_SDR_GAIN_MODE_MANUAL);
+    settle_ms(250);
+    (void)esp_rtl_sdr_get_tuner_gain_mode(sdr, &mode);
+    smoke_row("manual_restore_mode", err == ESP_OK && mode == ESP_RTL_SDR_GAIN_MODE_MANUAL);
+
+    err = esp_rtl_sdr_set_tuner_gain(sdr, 297);
+    settle_ms(250);
+    (void)esp_rtl_sdr_get_tuner_gain(sdr, &gain);
+    smoke_row("manual_restore_gain", err == ESP_OK && gain == 297);
+    smoke_read(sdr, "manual_restore_read");
 }
 
 void app_main(void)
@@ -79,68 +183,50 @@ void app_main(void)
     esp_rtl_sdr_config_t cfg;
     esp_rtl_sdr_config_default(&cfg);
     cfg.event_cb = on_event;
+    /* Default drop-in: BOTH + auto ring. Do not set pull_ring_bytes. */
     ESP_ERROR_CHECK(esp_rtl_sdr_config_validate(&cfg));
+    smoke_row("default_auto_ring", cfg.pull_ring_bytes == 0 &&
+                                       cfg.delivery_mode == ESP_RTL_SDR_DELIVERY_BOTH);
 
     esp_rtl_sdr_handle_t sdr = NULL;
     ESP_ERROR_CHECK(esp_rtl_sdr_install(&cfg, &sdr));
 
-    ESP_ERROR_CHECK(esp_rtl_sdr_apply_need(sdr, ESP_RTL_SDR_NEED_FM));
-    ESP_ERROR_CHECK(esp_rtl_sdr_apply_need(sdr, ESP_RTL_SDR_NEED_ADSB));
-    uint32_t hz = 0, sps = 0;
-    ESP_ERROR_CHECK(esp_rtl_sdr_get_center_freq(sdr, &hz));
-    ESP_ERROR_CHECK(esp_rtl_sdr_get_sample_rate(sdr, &sps));
-    ESP_LOGI(TAG, "after NEED_ADSB freq=%u sps=%u", (unsigned)hz, (unsigned)sps);
-
-    /* Continuous custom rate */
-    ESP_ERROR_CHECK(esp_rtl_sdr_set_sample_rate(sdr, 1536000));
-    ESP_ERROR_CHECK(esp_rtl_sdr_get_sample_rate(sdr, &sps));
-    ESP_LOGI(TAG, "continuous 1536k -> exact %u", (unsigned)sps);
-
-    esp_rtl_sdr_health_info_t health;
-    ESP_ERROR_CHECK(esp_rtl_sdr_get_health(sdr, &health));
-    ESP_LOGI(TAG, "health idle advice=%s", health.advice);
-
-    (void)esp_rtl_sdr_refresh_device_list(sdr);
-    size_t dev_count = 0;
-    (void)esp_rtl_sdr_get_device_count(sdr, &dev_count);
+    const char *hw = "SKIP";
+    const size_t dev_count = wait_devices(sdr, 3000);
     ESP_LOGI(TAG, "candidates=%u", (unsigned)dev_count);
 
-    /* Optional short passport if dongle present (can take ~entry*dwell). */
-    if (dev_count > 0) {
-        esp_rtl_sdr_passport_opts_t popts;
-        esp_rtl_sdr_passport_opts_default(&popts);
-        popts.dwell_ms = 800; /* short smoke dwell */
-        popts.recommended_only = true;
-        esp_rtl_sdr_rate_passport_t pass;
-        esp_err_t perr = esp_rtl_sdr_probe_rates(sdr, &popts, &pass);
-        ESP_LOGW(TAG, "probe_rates -> %s best_stable=%u entries=%u",
-                 esp_rtl_sdr_err_to_name(perr), (unsigned)pass.best_stable_sps,
-                 (unsigned)pass.entry_count);
-        if (perr == ESP_OK) {
-            ESP_ERROR_CHECK(esp_rtl_sdr_apply_need(sdr, ESP_RTL_SDR_NEED_MAX_STABLE));
+    if (dev_count == 0) {
+        smoke_row("no_device_skip", true);
+    } else {
+        hw = "RUN";
+        esp_rtl_sdr_stream_config_t stream;
+        esp_rtl_sdr_stream_config_default(&stream);
+        stream.preset = ESP_RTL_SDR_PRESET_CUSTOM_HZ;
+        stream.frequency_hz = 0;
+        stream.sample_rate_sps = 0;
+        const esp_err_t start_err = esp_rtl_sdr_start(sdr, &stream);
+        smoke_row("start", start_err == ESP_OK);
+        if (start_err == ESP_OK) {
+            settle_ms(400);
+            smoke_read(sdr, "first_read");
+            run_l4_matrix(sdr);
+
+            esp_rtl_sdr_metrics_t metrics;
+            esp_rtl_sdr_health_info_t health;
+            smoke_row("metrics_after", esp_rtl_sdr_get_metrics(sdr, &metrics) == ESP_OK &&
+                                           metrics.bytes_total > 0);
+            smoke_row("health_after", esp_rtl_sdr_get_health(sdr, &health) == ESP_OK);
+            ESP_LOGI(TAG, "metrics bytes=%llu overruns=%u drops=%u sps=%u",
+                     (unsigned long long)metrics.bytes_total, (unsigned)metrics.overruns,
+                     (unsigned)metrics.consumer_drops, (unsigned)metrics.effective_sps);
+            ESP_LOGI(TAG, "health overall=%d advice=%s", (int)health.overall, health.advice);
         }
     }
 
-    esp_rtl_sdr_stream_config_t stream;
-    esp_rtl_sdr_stream_config_default(&stream);
-    stream.preset = ESP_RTL_SDR_PRESET_CUSTOM_HZ;
-    stream.frequency_hz = 0; /* preferred */
-    stream.sample_rate_sps = 0;
-    esp_err_t err = esp_rtl_sdr_start(sdr, &stream);
-    ESP_LOGW(TAG, "start -> %s", esp_rtl_sdr_err_to_name(err));
-    if (err == ESP_OK) {
-        vTaskDelay(pdMS_TO_TICKS(400));
-        ESP_ERROR_CHECK(esp_rtl_sdr_get_health(sdr, &health));
-        ESP_LOGI(TAG, "health streaming overall=%d eff=%.2f advice=%s",
-                 (int)health.overall, (double)health.efficiency, health.advice);
-        uint8_t iq[4096];
-        size_t nbytes = 0;
-        err = esp_rtl_sdr_read(sdr, iq, sizeof(iq), 500, &nbytes);
-        ESP_LOGI(TAG, "read -> %s bytes=%u", esp_rtl_sdr_err_to_name(err),
-                 (unsigned)nbytes);
-    }
+    smoke_row("stop", esp_rtl_sdr_stop(sdr, 1000) == ESP_OK);
+    smoke_row("uninstall", esp_rtl_sdr_uninstall(sdr) == ESP_OK);
 
-    ESP_ERROR_CHECK(esp_rtl_sdr_stop(sdr, 1000));
-    ESP_ERROR_CHECK(esp_rtl_sdr_uninstall(sdr));
-    ESP_LOGI(TAG, "smoke complete");
+    const bool overall = (g_fail == 0);
+    printf("SMOKE OVERALL %s passed=%d failed=%d hardware=%s\n",
+           overall ? "PASS" : "FAIL", g_pass, g_fail, hw);
 }

--- a/examples/p4_serial_smoke/sdkconfig.defaults
+++ b/examples/p4_serial_smoke/sdkconfig.defaults
@@ -7,3 +7,7 @@ CONFIG_FREERTOS_HZ=1000
 
 # USB Host stack (P4)
 CONFIG_USB_HOST_CONTROL_TRANSFER_MAX_SIZE=1024
+
+# Tab5 ships ESP32-P4 revision v1.3 (pre-v3 silicon). Images that require
+# rev 3.1+ will refuse to flash.
+CONFIG_ESP32P4_REV_MIN_0=y

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,5 +1,5 @@
 ## esp_rtl_sdr — ESP Component Registry metadata
-version: "0.7.8"
+version: "0.7.9"
 description: >
   Clean-room ESP-IDF USB Host client for RTL2832U-class SDR dongles.
   Blog V4 (R828D) profile first; profile-based expansion for other tuners.

--- a/include/esp_rtl_sdr.h
+++ b/include/esp_rtl_sdr.h
@@ -87,7 +87,7 @@ extern "C" {
 /** Semantic version of this public header / binary API. */
 #define ESP_RTL_SDR_VERSION_MAJOR 0
 #define ESP_RTL_SDR_VERSION_MINOR 7
-#define ESP_RTL_SDR_VERSION_PATCH 8
+#define ESP_RTL_SDR_VERSION_PATCH 9
 
 #define ESP_RTL_SDR_VERSION_NUMBER                                      \
     ((ESP_RTL_SDR_VERSION_MAJOR * 10000) +                              \
@@ -500,9 +500,12 @@ typedef struct {
      */
     esp_rtl_sdr_delivery_mode_t delivery_mode;
     /**
-     * Optional pull-ring capacity in bytes (CU8). 0 = auto
-     * (~4× URB total, min ~192 KiB, max 512 KiB). Only allocated when the
-     * mode uses read() (lazy on first push/read).
+     * Optional pull-ring capacity in bytes (CU8). 0 = auto: prefer ~4× URB
+     * total (min ~192 KiB, max 512 KiB), then shrink to the largest even
+     * internal heap block down to 64 KiB if PSRAM/internal cannot take the
+     * preferred size (Tab5-class no-PSRAM drop-in). Non-zero is exact and
+     * fail-closed (ESP_ERR_NO_MEM, no shrink). Only allocated when the mode
+     * uses read() (lazy on first push/read).
      */
     size_t pull_ring_bytes;
 } esp_rtl_sdr_config_t;

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "esp_rtl_sdr",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "Clean-room ESP USB Host client for RTL2832U-class SDR (Blog V4 profile first)",
   "keywords": "sdr, rtl-sdr, rtl2832u, usb, esp32-p4, esp_rtl_sdr",
   "license": "AGPL-3.0-only",

--- a/src/esp_rtl_sdr.cpp
+++ b/src/esp_rtl_sdr.cpp
@@ -969,9 +969,41 @@ static void destroy_pull_ring_unlocked(esp_rtl_sdr_handle *h)
     }
 }
 
+static constexpr size_t kPullRingAutoMin = 64u * 1024u;  /* Tab5 no-PSRAM L4 */
+static constexpr size_t kPullRingAutoMax = 512u * 1024u;
+static constexpr size_t kPullRingAutoFloor = 96000u * 2u; /* ~0.2 s @ 960 kS/s CU8 */
+
+static size_t pull_ring_auto_prefer(const esp_rtl_sdr_handle *h)
+{
+    size_t need = h->cfg.transfer_bytes * h->cfg.transfer_count * 4u;
+    if (need < kPullRingAutoFloor) {
+        need = kPullRingAutoFloor;
+    }
+    if (need > kPullRingAutoMax) {
+        need = kPullRingAutoMax;
+    }
+    return need & ~size_t{1};
+}
+
+static uint8_t *malloc_pull_buf(size_t need)
+{
+    uint8_t *buf = static_cast<uint8_t *>(
+        heap_caps_malloc(need, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+    if (buf == nullptr) {
+        buf = static_cast<uint8_t *>(
+            heap_caps_malloc(need, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
+    }
+    return buf;
+}
+
 /**
  * Lazy pull-ring init. Serialized on the handle API lock so delivery_task and
  * esp_rtl_sdr_read cannot race a double-alloc or leave a half-initialized ring.
+ *
+ * Auto size prefers ~4× URB (min ~192 KiB). If that cannot allocate (typical
+ * Tab5-class board with no PSRAM), shrink to the largest even internal block
+ * down to 64 KiB so default drop-in still works. Explicit pull_ring_bytes
+ * stays fail-closed (NO_MEM, no shrink).
  */
 static esp_err_t ensure_pull_ring(esp_rtl_sdr_handle *h)
 {
@@ -993,30 +1025,57 @@ static esp_err_t ensure_pull_ring(esp_rtl_sdr_handle *h)
         destroy_pull_ring_unlocked(h);
     }
 
-    size_t need = h->cfg.pull_ring_bytes;
-    if (need == 0) {
-        /* ~0.2 s at 960 kS/s CU8 (192 KiB), or 4× URB total, cap 512 KiB. */
-        need = h->cfg.transfer_bytes * h->cfg.transfer_count * 4u;
-        if (need < 96000u * 2u) {
-            need = 96000u * 2u;
-        }
-        if (need > 512u * 1024u) {
-            need = 512u * 1024u;
-        }
-    }
+    const bool auto_size = (h->cfg.pull_ring_bytes == 0);
+    size_t need = auto_size ? pull_ring_auto_prefer(h) : h->cfg.pull_ring_bytes;
     need &= ~size_t{1};
     if (need < 2u) {
         return ESP_ERR_INVALID_ARG;
     }
 
-    uint8_t *buf = static_cast<uint8_t *>(
-        heap_caps_malloc(need, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
-    if (buf == nullptr) {
-        buf = static_cast<uint8_t *>(heap_caps_malloc(need, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
+    const size_t prefer = need;
+    uint8_t *buf = malloc_pull_buf(need);
+    if (buf == nullptr && auto_size) {
+        size_t largest = heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL |
+                                                          MALLOC_CAP_8BIT);
+        const size_t slack = 32u * 1024u;
+        if (largest > slack) {
+            largest -= slack;
+        } else {
+            largest = 0;
+        }
+        largest &= ~size_t{1};
+        static const size_t kLadder[] = {128u * 1024u, 96u * 1024u, kPullRingAutoMin};
+        size_t try_sz = largest;
+        if (try_sz > prefer) {
+            try_sz = prefer;
+        }
+        if (try_sz < kPullRingAutoMin) {
+            try_sz = kPullRingAutoMin;
+        }
+        buf = malloc_pull_buf(try_sz);
+        if (buf == nullptr) {
+            for (size_t i = 0; i < sizeof(kLadder) / sizeof(kLadder[0]); ++i) {
+                if (kLadder[i] >= try_sz && try_sz != kPullRingAutoMin) {
+                    continue;
+                }
+                buf = malloc_pull_buf(kLadder[i]);
+                if (buf != nullptr) {
+                    try_sz = kLadder[i];
+                    break;
+                }
+            }
+        }
+        if (buf != nullptr) {
+            ESP_LOGW(TAG, "pull ring auto shrunk %u -> %u (heap)",
+                     static_cast<unsigned>(prefer), static_cast<unsigned>(try_sz));
+            need = try_sz;
+        }
     }
     if (buf == nullptr) {
         return ESP_ERR_NO_MEM;
     }
+    ESP_LOGI(TAG, "pull ring %u bytes auto=%d", static_cast<unsigned>(need),
+             auto_size ? 1 : 0);
 
     SemaphoreHandle_t mux = xSemaphoreCreateMutex();
     SemaphoreHandle_t sem = xSemaphoreCreateBinary();


### PR DESCRIPTION
## Summary
- Auto pull-ring shrinks on no-PSRAM Tab5 instead of `ESP_ERR_NO_MEM` (64 KiB floor).
- `p4_serial_smoke` tests the real default (no 64 KiB override), L4 AUTO/RTL AGC rows, pre-v3 P4 silicon.
- Version bump 0.7.8 → 0.7.9. First immutable tag of the 0.7.8 bookmark line.

## Test plan
- [x] Host-side: truth hygiene files bumped together
- [ ] `examples/p4_serial_smoke` on Tab5 COM17 / Blog V4 (`SMOKE OVERALL PASS hardware=RUN`)
- [ ] L5 OrcSDR and L6 soak remain open

Hardware re-run still required before claiming drop-in verified.