### PR TITLE
release(0.7.10): Tab5 smoke URB A/B and quiet USB soak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+## 0.7.10 (2026-08-27)
+
+### Smoke / Tab5 USB
+
+- `examples/p4_serial_smoke` quiet USB soak at 960 kS/s (BOTH + auto ring,
+  helper `read()` drain, no mid-stream EP0). PASS if efficiency >= 90%.
+  **One USB host install per boot.** A/B URB layouts are two images:
+  default `6x16384` (`usb_soak_960k_6x16k`) and overlay `3x32768`
+  (`usb_soak_960k_3x32k`, `sdkconfig.defaults.urb_3x32k`). Do not re-install
+  the host in one run (IDF 5.5.4 `usb_host_uninstall` is not a reliable
+  re-entry on Tab5).
+- `sdkconfig.defaults` sets `CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y` plus
+  `CONFIG_ESP32P4_REV_MIN_0=y` (example-only). IDF 5.5.4 hides rev 0 behind
+  that parent symbol; without it Tab5 P4 v1.3 gets a v3.1 bootloader and
+  esptool refuses. P4 rev <3.0 vs >=3.0 images are mutually exclusive.
+- Example `PROJECT_VER` is `0.7.10` so the image identity is not git-describe
+  of tag v0.7.9.
+- The 0.7.9 Tab5 79% USB_STARVING figure mixed L4 gain/AGC bulk-pauses with a
+  sparse BOTH `read()`. Those `consumer_drops` are not the starve signal.
+  Hardware re-soak of both URB images is Tab5-operator work against this tag.
+
 ## 0.7.9 (2026-08-26)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Make an RTL-SDR Blog V4 a first-class peripheral on ESP32-P4** — continuous I/Q over USB Host, with a real embedded driver API.
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
-![Status](https://img.shields.io/badge/version-0.7.9-green)
+![Status](https://img.shields.io/badge/version-0.7.10-green)
 [![GitHub](https://img.shields.io/badge/github-esp--rtl--sdr-black)](https://github.com/hardcoreerik/esp-rtl-sdr)
 ![Target](https://img.shields.io/badge/ESP32--P4-HS_USB-green)
 

--- a/docs/V0_7_10_TAB5_HANDOFF.md
+++ b/docs/V0_7_10_TAB5_HANDOFF.md
@@ -1,0 +1,54 @@
+# v0.7.10 handoff (driver -> Tab5 operator)
+
+Immutable once tagged: `v0.7.10` on `https://github.com/hardcoreerik/esp-rtl-sdr`.
+
+## What this release is
+
+- Public version macros / `idf_component.yml` / `library.json`: **0.7.10**
+- Smoke example: quiet USB soak + L4 matrix; Tab5 P4 rev defaults
+- **Not** a claim that Tab5 USB efficiency is fixed. Hardware soak is your job.
+
+## Do not use
+
+- Dirty worktree builds (`v0.7.9-dirty`, untagged `grok/v0.7.10-usb-starve` WIP)
+- Log `p4_serial_smoke_COM17_0_7_10_usb_soak_2026-08-26.txt` (FAILED soaks:
+  `ESP_ERR_INVALID_STATE` from multi-install). Discard as evidence.
+
+## Build both images (NEWCOREPC, IDF 5.5.4)
+
+Checkout **tag `v0.7.10`** only.
+
+```bat
+cd examples\p4_serial_smoke
+
+rem --- A: 6x16 KiB ---
+idf.py set-target esp32p4
+idf.py build
+rem confirm project_description.json project_version == 0.7.10
+rem confirm min_rev == 0
+idf.py -p COM17 flash monitor
+
+rem --- B: 3x32 KiB (separate build dir) ---
+idf.py -B build-3x32k -D SDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.defaults.urb_3x32k" set-target esp32p4
+idf.py -B build-3x32k build
+idf.py -B build-3x32k -p COM17 flash monitor
+```
+
+Boot must print `esp_rtl_sdr 0.7.10 soak=usb_soak_960k_6x16k urbs=6x16384`
+or `... soak=usb_soak_960k_3x32k urbs=3x32768`.
+
+## Pass criteria (each image)
+
+- `SMOKE <soak-row> PASS`
+- `SOAK ... eff>=90` and advice not USB starving
+- `SMOKE OVERALL PASS ... hardware=RUN`
+- Preserve serial log + bin SHA-256 under
+  `\\HARDCOREPC\HARDCOREPC F-Drive\Ai\ESP_RTL_SDR\docs\Test_reports\`
+- Restore OrcSDR on COM17 when done (Codex)
+
+## Host tests (already green on author machine)
+
+```bat
+tests\scripts\run_host_tests.ps1
+rem expect: RESULT passed=225 failed=0  HOST_TESTS_OK
+```

--- a/examples/p4_serial_smoke/CMakeLists.txt
+++ b/examples/p4_serial_smoke/CMakeLists.txt
@@ -1,7 +1,11 @@
 cmake_minimum_required(VERSION 3.16)
 
+# Pin app version so idf.py project_description is 0.7.10, not git-describe
+# of the previous tag (v0.7.9-dirty).
+set(PROJECT_VER "0.7.10")
+
 # Component is examples/p4_serial_smoke/components/esp_rtl_sdr (stable name).
-# Do not set EXTRA_COMPONENT_DIRS to the repo root — the component name would
+# Do not set EXTRA_COMPONENT_DIRS to the repo root - the component name would
 # become the checkout folder name (e.g. esp-rtl-sdr).
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)

--- a/examples/p4_serial_smoke/README.md
+++ b/examples/p4_serial_smoke/README.md
@@ -1,11 +1,22 @@
 # p4_serial_smoke
 
-ESP-IDF app that links **esp_rtl_sdr** and exercises the public 0.7.9 drop-in
+ESP-IDF app that links **esp_rtl_sdr** and exercises the public 0.7.10 drop-in
 contract on ESP32-P4 / Tab5.
 
-Default install only: `delivery_mode` BOTH, `pull_ring_bytes` 0 (auto). The
-driver must shrink the auto ring if PSRAM is missing; this app must **not**
-hardcode 64 KiB.
+**One USB host install per boot.** IDF 5.5.4 `usb_host_uninstall` is not a
+reliable re-entry on Tab5, so A/B URB layouts are **two firmware images**,
+not two installs in one run.
+
+## URB layouts (Kconfig)
+
+| Image | Kconfig | `transfer_count x transfer_bytes` | Soak row |
+|---|---|---|---|
+| default | `CONFIG_ESP_RTL_SDR_SMOKE_URB_6X16K` | 6 x 16384 | `usb_soak_960k_6x16k` |
+| overlay | `CONFIG_ESP_RTL_SDR_SMOKE_URB_3X32K` | 3 x 32768 | `usb_soak_960k_3x32k` |
+
+Quiet soak: BOTH + auto ring, drain via `read()` on a helper task, no
+gain/AGC/bias during the window, 960 kS/s, 8 s default. PASS only if
+efficiency >= 90%. Then the L4 gain / Tuner AUTO / RTL AGC / `read()` matrix.
 
 IQ `EVT_IQ_BLOCK` logging is suppressed so serial cannot stall delivery.
 
@@ -13,30 +24,61 @@ IQ `EVT_IQ_BLOCK` logging is suppressed so serial cannot stall delivery.
 
 ```text
 SMOKE <name> PASS|FAIL
+SOAK <label> eff=<pct> sps=<n> bytes=<n> over=<n> drops=<n> short=<n> urbs=<c>x<b>
 SMOKE OVERALL PASS|FAIL passed=<n> failed=<n> hardware=RUN|SKIP
 ```
 
 No dongle: helpers + install/uninstall still pass (`hardware=SKIP`).
-Attached Blog V4: L4 gain / tuner AUTO / RTL AGC / read matrix (`hardware=RUN`).
+Attached Blog V4: soak + L4 (`hardware=RUN`).
 
-## Build (ESP32-P4)
+## Tab5 / P4 silicon (IDF 5.5.4)
+
+`sdkconfig.defaults` contains:
+
+```
+CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y
+CONFIG_ESP32P4_REV_MIN_0=y
+```
+
+Tab5 is ESP32-P4 **rev v1.3**. Without `SELECTS_REV_LESS_V3`, IDF 5.5.4 silently
+selects min_rev 3.1 and esptool refuses: bootloader requires [v3.1-v3.99], chip is v1.3.
+
+These symbols are **this example only**. They do not ship in the library. P4 rev
+<3.0 vs >=3.0 firmware is mutually exclusive; a v3.1+ module must not use this default.
+
+`CMakeLists.txt` sets `PROJECT_VER` to `0.7.10` so the image identity matches the
+driver, not git-describe of tag v0.7.9.
+
+## Build (ESP32-P4, IDF 5.5.4)
+
+Default image (6 x 16 KiB):
 
 ```bash
-export IDF_PATH=...   # ESP-IDF ≥ 5.3 with esp32p4 support
 cd examples/p4_serial_smoke
 idf.py set-target esp32p4
 idf.py build
-# optional: idf.py -p COMx flash monitor
+# Tab5: idf.py -p COM17 flash monitor
 ```
 
-`sdkconfig.defaults` selects pre-v3 P4 silicon so a Tab5 rev v1.3 can flash.
+3 x 32 KiB image (separate build dir recommended):
+
+```bash
+cd examples/p4_serial_smoke
+idf.py -B build-3x32k -D SDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.defaults.urb_3x32k" set-target esp32p4
+idf.py -B build-3x32k build
+# Tab5: idf.py -B build-3x32k -p COM17 flash monitor
+```
+
+Confirm at boot: `esp_rtl_sdr 0.7.10 soak=usb_soak_960k_6x16k urbs=6x16384`
+or `soak=usb_soak_960k_3x32k urbs=3x32768`. App version in
+`build/project_description.json` must be `0.7.10`.
 
 The component is pulled via `components/esp_rtl_sdr/` (stable name wrapping the
 repo root sources). No dongle is required for a successful **compile**.
 
+Hardware soak evidence is produced on COM17 by the Tab5 operator (Codex), not
+by this example's author flashing from a dirty tree.
+
 ## CI
 
-GitHub Actions job `idf-p4-build` only compiles (no hardware). Lab soak remains
-manual — see `docs/LAB_HOBBYIST.md` and `docs/TESTING_GUIDE.md`.
-
-L5 unchanged-consumer (OrcSDR) and L6 soak remain open.
+GitHub Actions job `idf-p4-build` compiles the default image (no hardware).

--- a/examples/p4_serial_smoke/main/Kconfig.projbuild
+++ b/examples/p4_serial_smoke/main/Kconfig.projbuild
@@ -1,0 +1,21 @@
+menu "esp_rtl_sdr p4_serial_smoke"
+
+choice ESP_RTL_SDR_SMOKE_URB
+    prompt "USB bulk URB layout for quiet soak"
+    default ESP_RTL_SDR_SMOKE_URB_6X16K
+    help
+        One layout per firmware image. Rebuild to A/B. Matches the fact that
+        usb_host_uninstall is not a reliable re-entry on IDF 5.5.4 Tab5.
+
+    config ESP_RTL_SDR_SMOKE_URB_6X16K
+        bool "6 x 16 KiB (library default)"
+    config ESP_RTL_SDR_SMOKE_URB_3X32K
+        bool "3 x 32 KiB (OrcSDR-like)"
+endchoice
+
+config ESP_RTL_SDR_SMOKE_SOAK_MS
+    int "Quiet soak duration (ms)"
+    default 8000
+    range 2000 60000
+
+endmenu

--- a/examples/p4_serial_smoke/main/main.c
+++ b/examples/p4_serial_smoke/main/main.c
@@ -1,17 +1,21 @@
 /*
- * ESP-IDF Tab5 / P4 drop-in smoke for esp_rtl_sdr public API (v0.7.9).
+ * ESP-IDF Tab5 / P4 drop-in smoke for esp_rtl_sdr public API (v0.7.10).
  *
- * Default config only: delivery BOTH, pull_ring_bytes = 0 (auto). The driver
- * must allocate on no-PSRAM Tab5-class heaps; do not hardcode 64 KiB here.
- * IQ event logging is suppressed so serial cannot stall the delivery path.
+ * One USB host install per boot. URB layout is a Kconfig choice so A/B
+ * (6x16 KiB vs 3x32 KiB) is two firmware images, not two installs.
+ *
+ * Quiet soak: BOTH + auto ring, drain via read() on a helper task, no
+ * mid-stream EP0, then L4 gain / AUTO / RTL AGC matrix.
  *
  * Grep-friendly rows:
  *   SMOKE <name> PASS|FAIL
+ *   SOAK <label> eff=<pct> sps=<n> bytes=<n> over=<n> drops=<n> short=<n> urbs=<c>x<b>
  *   SMOKE OVERALL PASS|FAIL passed=<n> failed=<n> hardware=<RUN|SKIP>
  */
 #include <stdio.h>
 #include <string.h>
 
+#include "sdkconfig.h"
 #include "esp_log.h"
 #include "nvs_flash.h"
 #include "freertos/FreeRTOS.h"
@@ -20,8 +24,23 @@
 
 static const char *TAG = "esp_rtl_sdr_smoke";
 
+#if CONFIG_ESP_RTL_SDR_SMOKE_URB_3X32K
+#define SMOKE_XFER_COUNT 3u
+#define SMOKE_XFER_BYTES 32768u
+#define SMOKE_SOAK_NAME "usb_soak_960k_3x32k"
+#else
+#define SMOKE_XFER_COUNT 6u
+#define SMOKE_XFER_BYTES 16384u
+#define SMOKE_SOAK_NAME "usb_soak_960k_6x16k"
+#endif
+
+#ifndef CONFIG_ESP_RTL_SDR_SMOKE_SOAK_MS
+#define CONFIG_ESP_RTL_SDR_SMOKE_SOAK_MS 8000
+#endif
+
 static int g_pass;
 static int g_fail;
+static volatile bool g_drain;
 
 static void smoke_row(const char *name, bool ok)
 {
@@ -39,13 +58,12 @@ static void on_event(esp_rtl_sdr_event_t event, const void *payload, void *ctx)
 {
     (void)ctx;
     if (event == ESP_RTL_SDR_EVT_IQ_BLOCK) {
-        return; /* never log IQ; serial stalls the delivery path */
+        return;
     }
     if (event == ESP_RTL_SDR_EVT_PASSPORT_PROGRESS && payload != NULL) {
         const esp_rtl_sdr_passport_entry_t *e = payload;
         ESP_LOGI(TAG, "passport progress rate=%u eff=%u stable=%d",
                  (unsigned)e->exact_sps, (unsigned)e->effective_sps, (int)e->stable);
-        return;
     }
 }
 
@@ -81,6 +99,17 @@ static size_t wait_devices(esp_rtl_sdr_handle_t sdr, int timeout_ms)
     return 0;
 }
 
+static void drain_task(void *arg)
+{
+    esp_rtl_sdr_handle_t sdr = (esp_rtl_sdr_handle_t)arg;
+    uint8_t buf[16384];
+    while (g_drain) {
+        size_t n = 0;
+        (void)esp_rtl_sdr_read(sdr, buf, sizeof(buf), 50, &n);
+    }
+    vTaskDelete(NULL);
+}
+
 static void check_pure_helpers(void)
 {
     uint32_t q = 0;
@@ -95,7 +124,7 @@ static void check_pure_helpers(void)
     smoke_row("rate_4M_reject", !esp_rtl_sdr_is_rate_supported(4000000));
 
     const char *ver = esp_rtl_sdr_get_version_string();
-    smoke_row("version_0_7_9", ver != NULL && strcmp(ver, "0.7.9") == 0);
+    smoke_row("version_0_7_10", ver != NULL && strcmp(ver, "0.7.10") == 0);
 
     const uint32_t caps = esp_rtl_sdr_get_capabilities();
     smoke_row("cap_gain", (caps & ESP_RTL_SDR_CAP_GAIN) != 0);
@@ -104,7 +133,9 @@ static void check_pure_helpers(void)
     smoke_row("cap_bias_tee", (caps & ESP_RTL_SDR_CAP_BIAS_TEE) != 0);
     smoke_row("cap_sync_read", (caps & ESP_RTL_SDR_CAP_SYNC_READ) != 0);
 
-    ESP_LOGI(TAG, "helpers version=%s caps=0x%08x", ver, (unsigned)caps);
+    ESP_LOGI(TAG, "helpers version=%s caps=0x%08x urbs=%ux%u soak_ms=%d",
+             ver, (unsigned)caps, SMOKE_XFER_COUNT, SMOKE_XFER_BYTES,
+             CONFIG_ESP_RTL_SDR_SMOKE_SOAK_MS);
 }
 
 static void run_l4_matrix(esp_rtl_sdr_handle_t sdr)
@@ -174,19 +205,65 @@ static void run_l4_matrix(esp_rtl_sdr_handle_t sdr)
     smoke_read(sdr, "manual_restore_read");
 }
 
+static void run_quiet_soak(esp_rtl_sdr_handle_t sdr)
+{
+    esp_rtl_sdr_metrics_t before;
+    memset(&before, 0, sizeof(before));
+    (void)esp_rtl_sdr_get_metrics(sdr, &before);
+
+    g_drain = true;
+    if (xTaskCreate(drain_task, "soak_drain", 4096, sdr, 5, NULL) != pdPASS) {
+        g_drain = false;
+        smoke_row(SMOKE_SOAK_NAME, false);
+        return;
+    }
+
+    settle_ms(CONFIG_ESP_RTL_SDR_SMOKE_SOAK_MS);
+    g_drain = false;
+    settle_ms(80);
+
+    esp_rtl_sdr_metrics_t after;
+    esp_rtl_sdr_health_info_t health;
+    memset(&after, 0, sizeof(after));
+    memset(&health, 0, sizeof(health));
+    (void)esp_rtl_sdr_get_metrics(sdr, &after);
+    (void)esp_rtl_sdr_get_health(sdr, &health);
+
+    const int eff_pct = (int)(health.efficiency * 100.0f + 0.5f);
+    printf("SOAK %s eff=%d sps=%u bytes=%llu over=%u drops=%u short=%u urbs=%ux%u advice=%s\n",
+           SMOKE_SOAK_NAME, eff_pct, (unsigned)after.effective_sps,
+           (unsigned long long)after.bytes_total, (unsigned)after.overruns,
+           (unsigned)after.consumer_drops, (unsigned)after.short_transfers,
+           SMOKE_XFER_COUNT, SMOKE_XFER_BYTES, health.advice);
+    ESP_LOGI(TAG, "soak overall=%d eff=%.3f programmed=%u delta_bytes=%llu",
+             (int)health.overall, (double)health.efficiency,
+             (unsigned)health.programmed_sps,
+             (unsigned long long)(after.bytes_total - before.bytes_total));
+
+    const bool ok = (after.bytes_total > before.bytes_total) &&
+                    (health.efficiency >= 0.90f) &&
+                    (health.overall != ESP_RTL_SDR_HEALTH_USB_STARVING);
+    smoke_row(SMOKE_SOAK_NAME, ok);
+}
+
 void app_main(void)
 {
     ESP_ERROR_CHECK(nvs_flash_init());
-    ESP_LOGI(TAG, "esp_rtl_sdr %s", esp_rtl_sdr_get_version_string());
+    ESP_LOGI(TAG, "esp_rtl_sdr %s soak=%s urbs=%ux%u",
+             esp_rtl_sdr_get_version_string(), SMOKE_SOAK_NAME,
+             SMOKE_XFER_COUNT, SMOKE_XFER_BYTES);
     check_pure_helpers();
 
     esp_rtl_sdr_config_t cfg;
     esp_rtl_sdr_config_default(&cfg);
     cfg.event_cb = on_event;
-    /* Default drop-in: BOTH + auto ring. Do not set pull_ring_bytes. */
+    cfg.transfer_count = SMOKE_XFER_COUNT;
+    cfg.transfer_bytes = SMOKE_XFER_BYTES;
     ESP_ERROR_CHECK(esp_rtl_sdr_config_validate(&cfg));
     smoke_row("default_auto_ring", cfg.pull_ring_bytes == 0 &&
                                        cfg.delivery_mode == ESP_RTL_SDR_DELIVERY_BOTH);
+    smoke_row("urb_layout_applied", cfg.transfer_count == SMOKE_XFER_COUNT &&
+                                        cfg.transfer_bytes == SMOKE_XFER_BYTES);
 
     esp_rtl_sdr_handle_t sdr = NULL;
     ESP_ERROR_CHECK(esp_rtl_sdr_install(&cfg, &sdr));
@@ -202,13 +279,14 @@ void app_main(void)
         esp_rtl_sdr_stream_config_t stream;
         esp_rtl_sdr_stream_config_default(&stream);
         stream.preset = ESP_RTL_SDR_PRESET_CUSTOM_HZ;
-        stream.frequency_hz = 0;
-        stream.sample_rate_sps = 0;
+        stream.frequency_hz = 96100000;
+        stream.sample_rate_sps = 960000;
         const esp_err_t start_err = esp_rtl_sdr_start(sdr, &stream);
         smoke_row("start", start_err == ESP_OK);
         if (start_err == ESP_OK) {
             settle_ms(400);
             smoke_read(sdr, "first_read");
+            run_quiet_soak(sdr);
             run_l4_matrix(sdr);
 
             esp_rtl_sdr_metrics_t metrics;

--- a/examples/p4_serial_smoke/sdkconfig.defaults
+++ b/examples/p4_serial_smoke/sdkconfig.defaults
@@ -1,4 +1,4 @@
-# CI / smoke defaults — ESP32-P4 High-Speed USB host path
+# CI / smoke defaults - ESP32-P4 High-Speed USB host path
 CONFIG_IDF_TARGET="esp32p4"
 
 # Leave headroom for USB host + C++ driver tasks
@@ -8,6 +8,10 @@ CONFIG_FREERTOS_HZ=1000
 # USB Host stack (P4)
 CONFIG_USB_HOST_CONTROL_TRANSFER_MAX_SIZE=1024
 
-# Tab5 ships ESP32-P4 revision v1.3 (pre-v3 silicon). Images that require
-# rev 3.1+ will refuse to flash.
+# Tab5 ships ESP32-P4 revision v1.3 (pre-v3 silicon). IDF 5.5.4 hides
+# ESP32P4_REV_MIN_0 behind SELECTS_REV_LESS_V3; without that parent symbol,
+# set-target silently builds min_rev 3.1 and esptool refuses Tab5.
+# P4 rev <3.0 vs >=3.0 images are mutually exclusive. This example is for
+# Tab5-class boards. Newer P4 rev v3.x boards must not use these two lines.
+CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y
 CONFIG_ESP32P4_REV_MIN_0=y

--- a/examples/p4_serial_smoke/sdkconfig.defaults.urb_3x32k
+++ b/examples/p4_serial_smoke/sdkconfig.defaults.urb_3x32k
@@ -1,0 +1,4 @@
+# Overlay: select 3x32 KiB URB layout for this image.
+# Use with: idf.py -D SDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.defaults.urb_3x32k" set-target esp32p4
+# CONFIG_ESP_RTL_SDR_SMOKE_URB_6X16K is not set
+CONFIG_ESP_RTL_SDR_SMOKE_URB_3X32K=y

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,5 +1,5 @@
 ## esp_rtl_sdr — ESP Component Registry metadata
-version: "0.7.9"
+version: "0.7.10"
 description: >
   Clean-room ESP-IDF USB Host client for RTL2832U-class SDR dongles.
   Blog V4 (R828D) profile first; profile-based expansion for other tuners.

--- a/include/esp_rtl_sdr.h
+++ b/include/esp_rtl_sdr.h
@@ -87,7 +87,7 @@ extern "C" {
 /** Semantic version of this public header / binary API. */
 #define ESP_RTL_SDR_VERSION_MAJOR 0
 #define ESP_RTL_SDR_VERSION_MINOR 7
-#define ESP_RTL_SDR_VERSION_PATCH 9
+#define ESP_RTL_SDR_VERSION_PATCH 10
 
 #define ESP_RTL_SDR_VERSION_NUMBER                                      \
     ((ESP_RTL_SDR_VERSION_MAJOR * 10000) +                              \

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "esp_rtl_sdr",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "Clean-room ESP USB Host client for RTL2832U-class SDR (Blog V4 profile first)",
   "keywords": "sdr, rtl-sdr, rtl2832u, usb, esp32-p4, esp_rtl_sdr",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
## Summary
- Quiet USB soak in `examples/p4_serial_smoke` (one install per boot)
- Kconfig URB A/B: 6x16 KiB default and 3x32 KiB overlay
- Tab5 P4 pre-v3 `sdkconfig.defaults` (`SELECTS_REV_LESS_V3` + `REV_MIN_0`)
- `PROJECT_VER` 0.7.10; public version 0.7.10
- Handoff: `docs/V0_7_10_TAB5_HANDOFF.md`
- Host tests: 225/0
- Immutable tag: `v0.7.10` = commit `3c696483ef35199cd35cb87ddd6878d87ac3aac3`

Hardware soak is Tab5-operator work against the tag (not claimed fixed here).

## Test plan
- [x] `tests/scripts/run_host_tests.ps1` passed=225 failed=0
- [ ] Codex: build both images from tag, flash COM17, preserve SOAK logs, restore OrcSDR