### PR TITLE
release(0.7.11): fix p4_serial_smoke soak_drain stack overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## 0.7.11 (2026-08-27)
+
+### Fixed
+
+- **p4_serial_smoke soak_drain stack overflow ([#11](https://github.com/hardcoreerik/esp-rtl-sdr/issues/11)):**
+  drain_task allocated a 16 KiB local buffer on a 4096-byte FreeRTOS task
+  stack (xTaskCreate sizes are bytes). Buffer is now a single static 16 KiB
+  array. Smoke harness only; driver streaming engine unchanged. Tag `v0.7.10`
+  is immutable. Re-soak both URB images against this tag.
+
 ## 0.7.10 (2026-08-27)
 
 ### Smoke / Tab5 USB

--- a/PROJECT_TRUTH.md
+++ b/PROJECT_TRUTH.md
@@ -6,8 +6,8 @@ wins for *what is true right now*.
 Same discipline as [TheOrc PROJECT_TRUTH](https://github.com/hardcoreerik/TheOrc):
 claims need evidence labels; oversell is a bug; retract rather than spin.
 
-Snapshot date: **2026-08-26**  
-Version: **0.7.9** (Tab5 auto-ring drop-in shrink; Tuner AUTO + RTL AGC — not production-ready)  
+Snapshot date: **2026-08-27**  
+Version: **0.7.11** (smoke `soak_drain` stack fix; USB soak still operator work — not production-ready)  
 Local repo: `F:\Ai\ESP_RTL_SDR\`  
 Remote: **https://github.com/hardcoreerik/esp-rtl-sdr**  
 Open-source honesty: [docs/AI_DEVELOPMENT_DISCLOSURE.md](docs/AI_DEVELOPMENT_DISCLOSURE.md) ·
@@ -119,6 +119,8 @@ Product vision: **`docs/VISION.md`**. Silicon / DS map: **`docs/SILICON.md`**.
 | **0.7.7** | HF upconverter CAP (RF+28.8e6) |
 | **0.7.8** | Measured Tuner AUTO + RTL digital AGC; IF filter USB-silent |
 | **0.7.9** | Auto pull-ring shrink for no-PSRAM Tab5; task-local REENTRANT |
+| **0.7.10** | Quiet USB soak + Tab5 P4 rev defaults (immutable; soak blocked by #11) |
+| **0.7.11** | Smoke soak_drain 16 KiB buffer off the 4 KiB task stack (#11) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Make an RTL-SDR Blog V4 a first-class peripheral on ESP32-P4** — continuous I/Q over USB Host, with a real embedded driver API.
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
-![Status](https://img.shields.io/badge/version-0.7.10-green)
+![Status](https://img.shields.io/badge/version-0.7.11-green)
 [![GitHub](https://img.shields.io/badge/github-esp--rtl--sdr-black)](https://github.com/hardcoreerik/esp-rtl-sdr)
 ![Target](https://img.shields.io/badge/ESP32--P4-HS_USB-green)
 

--- a/docs/V0_7_11_TAB5_HANDOFF.md
+++ b/docs/V0_7_11_TAB5_HANDOFF.md
@@ -1,0 +1,61 @@
+# v0.7.11 handoff (driver -> Tab5 operator)
+
+Immutable once tagged: `v0.7.11` on `https://github.com/hardcoreerik/esp-rtl-sdr`.
+
+Supersedes the hardware soak of `v0.7.10`. That tag is still valid software
+(host tests 225/225, both images built) but `p4_serial_smoke` `soak_drain`
+overflowed a 4 KiB task stack with a 16 KiB local buffer (issue #11). Do not
+re-flash `v0.7.10` for soak evidence.
+
+## What this release is
+
+- Public version macros / `idf_component.yml` / `library.json`: **0.7.11**
+- Smoke example: same quiet USB soak + L4 matrix as 0.7.10, plus `s_drain_buf`
+  moved off the `soak_drain` stack
+- **Not** a claim that Tab5 USB efficiency is fixed. Hardware soak is your job.
+
+## Do not use
+
+- Tag `v0.7.10` for soak (issue #11)
+- Dirty worktree builds
+- Log `p4_serial_smoke_COM17_0_7_10_usb_soak_2026-08-26.txt` (INVALID_STATE)
+
+## Build both images (NEWCOREPC, IDF 5.5.4)
+
+Checkout **tag `v0.7.11`** only.
+
+```bat
+cd examples\p4_serial_smoke
+
+rem --- A: 6x16 KiB ---
+idf.py set-target esp32p4
+idf.py build
+rem confirm project_description.json project_version == 0.7.11
+rem confirm min_rev == 0
+idf.py -p COM17 flash monitor
+
+rem --- B: 3x32 KiB (separate build dir) ---
+idf.py -B build-3x32k -D SDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.defaults.urb_3x32k" set-target esp32p4
+idf.py -B build-3x32k build
+idf.py -B build-3x32k -p COM17 flash monitor
+```
+
+Boot must print `esp_rtl_sdr 0.7.11 soak=usb_soak_960k_6x16k urbs=6x16384`
+or `... soak=usb_soak_960k_3x32k urbs=3x32768`.
+
+## Pass criteria (each image)
+
+- No stack-protection fault in `soak_drain`
+- `SMOKE <soak-row> PASS`
+- `SOAK ... eff>=90` and advice not USB starving
+- `SMOKE OVERALL PASS ... hardware=RUN`
+- Preserve serial log + bin SHA-256 under
+  `\\HARDCOREPC\HARDCOREPC F-Drive\Ai\ESP_RTL_SDR\docs\Test_reports\`
+- Restore OrcSDR on COM17 when done (Codex)
+
+## Host tests (already green on author machine)
+
+```bat
+tests\scripts\run_host_tests.ps1
+rem expect: RESULT passed=225 failed=0  HOST_TESTS_OK
+```

--- a/examples/p4_serial_smoke/CMakeLists.txt
+++ b/examples/p4_serial_smoke/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 
-# Pin app version so idf.py project_description is 0.7.10, not git-describe
-# of the previous tag (v0.7.9-dirty).
-set(PROJECT_VER "0.7.10")
+# Pin app version so idf.py project_description is 0.7.11, not git-describe
+# of an older tag.
+set(PROJECT_VER "0.7.11")
 
 # Component is examples/p4_serial_smoke/components/esp_rtl_sdr (stable name).
 # Do not set EXTRA_COMPONENT_DIRS to the repo root - the component name would

--- a/examples/p4_serial_smoke/README.md
+++ b/examples/p4_serial_smoke/README.md
@@ -1,6 +1,6 @@
 # p4_serial_smoke
 
-ESP-IDF app that links **esp_rtl_sdr** and exercises the public 0.7.10 drop-in
+ESP-IDF app that links **esp_rtl_sdr** and exercises the public 0.7.11 drop-in
 contract on ESP32-P4 / Tab5.
 
 **One USB host install per boot.** IDF 5.5.4 `usb_host_uninstall` is not a
@@ -46,8 +46,8 @@ selects min_rev 3.1 and esptool refuses: bootloader requires [v3.1-v3.99], chip 
 These symbols are **this example only**. They do not ship in the library. P4 rev
 <3.0 vs >=3.0 firmware is mutually exclusive; a v3.1+ module must not use this default.
 
-`CMakeLists.txt` sets `PROJECT_VER` to `0.7.10` so the image identity matches the
-driver, not git-describe of tag v0.7.9.
+`CMakeLists.txt` sets `PROJECT_VER` to `0.7.11` so the image identity matches the
+driver, not git-describe of an older tag.
 
 ## Build (ESP32-P4, IDF 5.5.4)
 
@@ -69,9 +69,9 @@ idf.py -B build-3x32k build
 # Tab5: idf.py -B build-3x32k -p COM17 flash monitor
 ```
 
-Confirm at boot: `esp_rtl_sdr 0.7.10 soak=usb_soak_960k_6x16k urbs=6x16384`
+Confirm at boot: `esp_rtl_sdr 0.7.11 soak=usb_soak_960k_6x16k urbs=6x16384`
 or `soak=usb_soak_960k_3x32k urbs=3x32768`. App version in
-`build/project_description.json` must be `0.7.10`.
+`build/project_description.json` must be `0.7.11`.
 
 The component is pulled via `components/esp_rtl_sdr/` (stable name wrapping the
 repo root sources). No dongle is required for a successful **compile**.

--- a/examples/p4_serial_smoke/main/main.c
+++ b/examples/p4_serial_smoke/main/main.c
@@ -1,5 +1,5 @@
 /*
- * ESP-IDF Tab5 / P4 drop-in smoke for esp_rtl_sdr public API (v0.7.10).
+ * ESP-IDF Tab5 / P4 drop-in smoke for esp_rtl_sdr public API (v0.7.11).
  *
  * One USB host install per boot. URB layout is a Kconfig choice so A/B
  * (6x16 KiB vs 3x32 KiB) is two firmware images, not two installs.
@@ -99,13 +99,16 @@ static size_t wait_devices(esp_rtl_sdr_handle_t sdr, int timeout_ms)
     return 0;
 }
 
+/* Off-stack: xTaskCreate stack is 4 KiB; a 16 KiB local blew soak_drain
+ * (issue #11). One soak at a time, so a single static buffer is enough. */
+static uint8_t s_drain_buf[16384];
+
 static void drain_task(void *arg)
 {
     esp_rtl_sdr_handle_t sdr = (esp_rtl_sdr_handle_t)arg;
-    uint8_t buf[16384];
     while (g_drain) {
         size_t n = 0;
-        (void)esp_rtl_sdr_read(sdr, buf, sizeof(buf), 50, &n);
+        (void)esp_rtl_sdr_read(sdr, s_drain_buf, sizeof(s_drain_buf), 50, &n);
     }
     vTaskDelete(NULL);
 }
@@ -124,7 +127,7 @@ static void check_pure_helpers(void)
     smoke_row("rate_4M_reject", !esp_rtl_sdr_is_rate_supported(4000000));
 
     const char *ver = esp_rtl_sdr_get_version_string();
-    smoke_row("version_0_7_10", ver != NULL && strcmp(ver, "0.7.10") == 0);
+    smoke_row("version_0_7_11", ver != NULL && strcmp(ver, "0.7.11") == 0);
 
     const uint32_t caps = esp_rtl_sdr_get_capabilities();
     smoke_row("cap_gain", (caps & ESP_RTL_SDR_CAP_GAIN) != 0);

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,5 +1,5 @@
 ## esp_rtl_sdr — ESP Component Registry metadata
-version: "0.7.10"
+version: "0.7.11"
 description: >
   Clean-room ESP-IDF USB Host client for RTL2832U-class SDR dongles.
   Blog V4 (R828D) profile first; profile-based expansion for other tuners.

--- a/include/esp_rtl_sdr.h
+++ b/include/esp_rtl_sdr.h
@@ -87,7 +87,7 @@ extern "C" {
 /** Semantic version of this public header / binary API. */
 #define ESP_RTL_SDR_VERSION_MAJOR 0
 #define ESP_RTL_SDR_VERSION_MINOR 7
-#define ESP_RTL_SDR_VERSION_PATCH 10
+#define ESP_RTL_SDR_VERSION_PATCH 11
 
 #define ESP_RTL_SDR_VERSION_NUMBER                                      \
     ((ESP_RTL_SDR_VERSION_MAJOR * 10000) +                              \

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "esp_rtl_sdr",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "Clean-room ESP USB Host client for RTL2832U-class SDR (Blog V4 profile first)",
   "keywords": "sdr, rtl-sdr, rtl2832u, usb, esp32-p4, esp_rtl_sdr",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
## Summary
- Move `p4_serial_smoke` soak drain buffer off the `soak_drain` task stack (issue #11).
- Bump public version to 0.7.11. Tag `v0.7.10` stays immutable.
- Host tests: `RESULT passed=225 failed=0`.

Smoke harness only. Does not claim USB starving is fixed.

## Test plan
- [x] `tests\scripts\run_host_tests.ps1` → 225/0
- [ ] Codex: both Tab5 images on COM17 (`usb_soak_960k_6x16k` and `usb_soak_960k_3x32k`) with no stack-protection fault, then restore OrcSDR