### PR TITLE
release(0.7.12): scope p4_serial_smoke SOAK to the drain window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build/
 tests/host/build/
 examples/**/build/
+examples/**/build-*/
 sdkconfig
 sdkconfig.old
 sdkconfig.defaults.esp32p4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
   delta consumer drops == 0, scoped advice not `USB_STARVING` or
   `APP_TOO_SLOW`, continuing IQ, and overall hardware PASS. Driver streaming
   engine unchanged. Tag `v0.7.11` is immutable.
+- **p4_serial_smoke A/B URB images shared one project-root `sdkconfig`:**
+  IDF 5.5.4 `-B` does not move `sdkconfig`. Overlay `set-target` could make
+  the later default image boot as `usb_soak_960k_3x32k`. Example now pins
+  `SDKCONFIG` under the `-B` directory; docs use `build-6x16k` /
+  `build-3x32k` with a pre-flash URB Kconfig grep. Smoke harness/docs only.
 
 ## 0.7.11 (2026-08-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+## 0.7.12 (2026-08-27)
+
+### Fixed
+
+- **p4_serial_smoke SOAK row attributed pre-soak pull-ring overflow to the 8 s drain:**
+  the harness waits 400 ms after `start()` before `first_read`, then starts
+  `soak_drain`. At 960 kS/s CU8 those cumulative `consumer_drops` match an
+  undrained ring, not the soak window. v0.7.11 Tab5 logs (507904 drops @
+  `6x16384`, 593920 @ `3x32768`) were that artifact. Smoke now restarts the
+  stream on the same USB host install (metrics and pull ring reset), drains
+  immediately, and reports scoped/delta bytes, overruns, drops, and advice
+  for the drain window. PASS requires efficiency >= 90%, delta overruns == 0,
+  delta consumer drops == 0, scoped advice not `USB_STARVING` or
+  `APP_TOO_SLOW`, continuing IQ, and overall hardware PASS. Driver streaming
+  engine unchanged. Tag `v0.7.11` is immutable.
+
 ## 0.7.11 (2026-08-27)
 
 ### Fixed

--- a/PROJECT_TRUTH.md
+++ b/PROJECT_TRUTH.md
@@ -7,7 +7,7 @@ Same discipline as [TheOrc PROJECT_TRUTH](https://github.com/hardcoreerik/TheOrc
 claims need evidence labels; oversell is a bug; retract rather than spin.
 
 Snapshot date: **2026-08-27**  
-Version: **0.7.11** (smoke `soak_drain` stack fix; USB soak still operator work — not production-ready)  
+Version: **0.7.12** (smoke SOAK row is the 8 s drain window; USB soak still operator work — not production-ready)
 Local repo: `F:\Ai\ESP_RTL_SDR\`  
 Remote: **https://github.com/hardcoreerik/esp-rtl-sdr**  
 Open-source honesty: [docs/AI_DEVELOPMENT_DISCLOSURE.md](docs/AI_DEVELOPMENT_DISCLOSURE.md) ·
@@ -121,6 +121,7 @@ Product vision: **`docs/VISION.md`**. Silicon / DS map: **`docs/SILICON.md`**.
 | **0.7.9** | Auto pull-ring shrink for no-PSRAM Tab5; task-local REENTRANT |
 | **0.7.10** | Quiet USB soak + Tab5 P4 rev defaults (immutable; soak blocked by #11) |
 | **0.7.11** | Smoke soak_drain 16 KiB buffer off the 4 KiB task stack (#11) |
+| **0.7.12** | Smoke SOAK evidence is scoped to the drain window (not pre-soak ring overflow) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Make an RTL-SDR Blog V4 a first-class peripheral on ESP32-P4** — continuous I/Q over USB Host, with a real embedded driver API.
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
-![Status](https://img.shields.io/badge/version-0.7.11-green)
+![Status](https://img.shields.io/badge/version-0.7.12-green)
 [![GitHub](https://img.shields.io/badge/github-esp--rtl--sdr-black)](https://github.com/hardcoreerik/esp-rtl-sdr)
 ![Target](https://img.shields.io/badge/ESP32--P4-HS_USB-green)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,7 +1,7 @@
 # esp_rtl_sdr public API — design contract
 
 **Header:** [`include/esp_rtl_sdr.h`](../include/esp_rtl_sdr.h)  
-**Version:** 0.7.9  
+**Version:** 0.7.12
 **Full parameter / return / example reference:** [`API_REFERENCE.md`](API_REFERENCE.md)
 
 This document is the **design contract** (invariants, threading, ABI growth).  

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # esp_rtl_sdr — API Reference
 
-> **Version tracked:** `0.7.9` (see `ESP_RTL_SDR_VERSION_*` in [`include/esp_rtl_sdr.h`](../include/esp_rtl_sdr.h))  
+> **Version tracked:** `0.7.12` (see `ESP_RTL_SDR_VERSION_*` in [`include/esp_rtl_sdr.h`](../include/esp_rtl_sdr.h))
 > **Header of record:** [`include/esp_rtl_sdr.h`](../include/esp_rtl_sdr.h)  
 > **Design contract (invariants, ABI growth):** [`API.md`](API.md)  
 > **What works on hardware right now:** [`../PROJECT_TRUTH.md`](../PROJECT_TRUTH.md) wins on any claim conflict.

--- a/docs/V0_7_12_TAB5_HANDOFF.md
+++ b/docs/V0_7_12_TAB5_HANDOFF.md
@@ -1,0 +1,63 @@
+# v0.7.12 handoff (driver -> Tab5 operator)
+
+Immutable once tagged: `v0.7.12` on `https://github.com/hardcoreerik/esp-rtl-sdr`.
+
+Supersedes the soak *evidence boundary* of `v0.7.11`. That tag is still valid
+software (stack-safe `soak_drain`) but the SOAK row printed cumulative
+`consumer_drops` from the 400 ms wait before `first_read`. Do not treat
+v0.7.11 Tab5 drop counts (507904 @ `6x16384`, 593920 @ `3x32768`) as drain
+evidence.
+
+## What this release is
+
+- Public version macros / `idf_component.yml` / `library.json`: **0.7.12**
+- Smoke example: same quiet USB soak + L4 matrix as 0.7.11, plus a same-install
+  stream restart so SOAK bytes/over/drops/advice are the 8 s drain window
+- **Not** a claim that Tab5 USB efficiency is fixed. Hardware soak is your job.
+
+## Do not use
+
+- Tag `v0.7.10` for soak (issue #11)
+- v0.7.11 SOAK `drops=` as proof the 8 s drain overflowed
+- Dirty worktree builds
+
+## Build both images (NEWCOREPC, IDF 5.5.4)
+
+Checkout **tag `v0.7.12`** only.
+
+```bat
+cd examples\p4_serial_smoke
+
+rem --- A: 6x16 KiB ---
+idf.py set-target esp32p4
+idf.py build
+rem confirm project_description.json project_version == 0.7.12
+rem confirm min_rev == 0
+idf.py -p COM17 flash monitor
+
+rem --- B: 3x32 KiB (separate build dir) ---
+idf.py -B build-3x32k -D SDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.defaults.urb_3x32k" set-target esp32p4
+idf.py -B build-3x32k build
+idf.py -B build-3x32k -p COM17 flash monitor
+```
+
+Boot must print `esp_rtl_sdr 0.7.12 soak=usb_soak_960k_6x16k urbs=6x16384`
+or `... soak=usb_soak_960k_3x32k urbs=3x32768`.
+
+## Pass criteria (each image)
+
+- No stack-protection fault in `soak_drain`
+- `SMOKE <soak-row> PASS`
+- `SOAK ...` uses scoped/delta bytes, overruns, drops; `eff>=90`; `over=0`;
+  `drops=0`; advice not `USB_STARVING` or `APP_TOO_SLOW`; IQ continuing
+- `SMOKE OVERALL PASS ... hardware=RUN`
+- Preserve serial log + bin SHA-256 under
+  `\\HARDCOREPC\HARDCOREPC F-Drive\Ai\ESP_RTL_SDR\docs\Test_reports\`
+- Restore OrcSDR on COM17 when done (Codex)
+
+## Host tests (already green on author machine)
+
+```bat
+tests\scripts\run_host_tests.ps1
+rem expect: RESULT passed=249 failed=0  HOST_TESTS_OK
+```

--- a/docs/V0_7_12_TAB5_HANDOFF.md
+++ b/docs/V0_7_12_TAB5_HANDOFF.md
@@ -25,19 +25,30 @@ evidence.
 
 Checkout **tag `v0.7.12`** only.
 
+IDF 5.5.4 `-B` does **not** isolate `sdkconfig`. Overlay `set-target` wrote
+the project-root file, so a later default `idf.py build` booted as
+`usb_soak_960k_3x32k`. Use a dedicated `-B` **and** `SDKCONFIG=` per image.
+Do not flash until the URB grep matches.
+
 ```bat
 cd examples\p4_serial_smoke
 
 rem --- A: 6x16 KiB ---
-idf.py set-target esp32p4
-idf.py build
-rem confirm project_description.json project_version == 0.7.12
+idf.py -B build-6x16k -D SDKCONFIG=build-6x16k/sdkconfig set-target esp32p4
+idf.py -B build-6x16k -D SDKCONFIG=build-6x16k/sdkconfig build
+findstr CONFIG_ESP_RTL_SDR_SMOKE_URB build-6x16k\sdkconfig
+rem require: CONFIG_ESP_RTL_SDR_SMOKE_URB_6X16K=y
+rem require: # CONFIG_ESP_RTL_SDR_SMOKE_URB_3X32K is not set
+rem confirm build-6x16k\project_description.json project_version == 0.7.12
 rem confirm min_rev == 0
-idf.py -p COM17 flash monitor
+idf.py -B build-6x16k -p COM17 flash monitor
 
-rem --- B: 3x32 KiB (separate build dir) ---
-idf.py -B build-3x32k -D SDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.defaults.urb_3x32k" set-target esp32p4
-idf.py -B build-3x32k build
+rem --- B: 3x32 KiB (separate build dir AND sdkconfig) ---
+idf.py -B build-3x32k -D SDKCONFIG=build-3x32k/sdkconfig -D SDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.defaults.urb_3x32k" set-target esp32p4
+idf.py -B build-3x32k -D SDKCONFIG=build-3x32k/sdkconfig -D SDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.defaults.urb_3x32k" build
+findstr CONFIG_ESP_RTL_SDR_SMOKE_URB build-3x32k\sdkconfig
+rem require: CONFIG_ESP_RTL_SDR_SMOKE_URB_3X32K=y
+rem require: # CONFIG_ESP_RTL_SDR_SMOKE_URB_6X16K is not set
 idf.py -B build-3x32k -p COM17 flash monitor
 ```
 

--- a/examples/p4_serial_smoke/CMakeLists.txt
+++ b/examples/p4_serial_smoke/CMakeLists.txt
@@ -4,6 +4,13 @@ cmake_minimum_required(VERSION 3.16)
 # of an older tag.
 set(PROJECT_VER "0.7.12")
 
+# IDF 5.5.4 defaults SDKCONFIG to ${CMAKE_SOURCE_DIR}/sdkconfig. -B only
+# changes the binary dir, so two URB images would share one config. Keep
+# sdkconfig inside the chosen -B directory unless the caller set SDKCONFIG.
+if(NOT SDKCONFIG)
+    set(SDKCONFIG "${CMAKE_BINARY_DIR}/sdkconfig")
+endif()
+
 # Component is examples/p4_serial_smoke/components/esp_rtl_sdr (stable name).
 # Do not set EXTRA_COMPONENT_DIRS to the repo root - the component name would
 # become the checkout folder name (e.g. esp-rtl-sdr).

--- a/examples/p4_serial_smoke/CMakeLists.txt
+++ b/examples/p4_serial_smoke/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 
-# Pin app version so idf.py project_description is 0.7.11, not git-describe
+# Pin app version so idf.py project_description is 0.7.12, not git-describe
 # of an older tag.
-set(PROJECT_VER "0.7.11")
+set(PROJECT_VER "0.7.12")
 
 # Component is examples/p4_serial_smoke/components/esp_rtl_sdr (stable name).
 # Do not set EXTRA_COMPONENT_DIRS to the repo root - the component name would

--- a/examples/p4_serial_smoke/README.md
+++ b/examples/p4_serial_smoke/README.md
@@ -56,27 +56,43 @@ driver, not git-describe of an older tag.
 
 ## Build (ESP32-P4, IDF 5.5.4)
 
+IDF 5.5.4 keeps `sdkconfig` in the **project directory** unless `SDKCONFIG` is
+set. `-B` alone is not isolation: overlay `set-target` can rewrite the file the
+default image then builds. This example pins `SDKCONFIG` under the `-B` dir.
+Still use two directories and two `sdkconfig` paths.
+
 Default image (6 x 16 KiB):
 
 ```bash
 cd examples/p4_serial_smoke
-idf.py set-target esp32p4
-idf.py build
-# Tab5: idf.py -p COM17 flash monitor
+idf.py -B build-6x16k -D SDKCONFIG=build-6x16k/sdkconfig set-target esp32p4
+idf.py -B build-6x16k -D SDKCONFIG=build-6x16k/sdkconfig build
+grep CONFIG_ESP_RTL_SDR_SMOKE_URB build-6x16k/sdkconfig
+# require: CONFIG_ESP_RTL_SDR_SMOKE_URB_6X16K=y
+# require: # CONFIG_ESP_RTL_SDR_SMOKE_URB_3X32K is not set
+# Tab5: idf.py -B build-6x16k -p COM17 flash monitor
 ```
 
-3 x 32 KiB image (separate build dir recommended):
+3 x 32 KiB image (separate build dir **and** sdkconfig):
 
 ```bash
 cd examples/p4_serial_smoke
-idf.py -B build-3x32k -D SDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.defaults.urb_3x32k" set-target esp32p4
-idf.py -B build-3x32k build
+idf.py -B build-3x32k -D SDKCONFIG=build-3x32k/sdkconfig \
+  -D SDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.defaults.urb_3x32k" set-target esp32p4
+idf.py -B build-3x32k -D SDKCONFIG=build-3x32k/sdkconfig \
+  -D SDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.defaults.urb_3x32k" build
+grep CONFIG_ESP_RTL_SDR_SMOKE_URB build-3x32k/sdkconfig
+# require: CONFIG_ESP_RTL_SDR_SMOKE_URB_3X32K=y
+# require: # CONFIG_ESP_RTL_SDR_SMOKE_URB_6X16K is not set
 # Tab5: idf.py -B build-3x32k -p COM17 flash monitor
 ```
 
+Do not flash until the matching `sdkconfig` grep is correct.
+
 Confirm at boot: `esp_rtl_sdr 0.7.12 soak=usb_soak_960k_6x16k urbs=6x16384`
 or `soak=usb_soak_960k_3x32k urbs=3x32768`. App version in
-`build/project_description.json` must be `0.7.12`.
+`build-6x16k/project_description.json` or
+`build-3x32k/project_description.json` must be `0.7.12`.
 
 The component is pulled via `components/esp_rtl_sdr/` (stable name wrapping the
 repo root sources). No dongle is required for a successful **compile**.

--- a/examples/p4_serial_smoke/README.md
+++ b/examples/p4_serial_smoke/README.md
@@ -1,6 +1,6 @@
 # p4_serial_smoke
 
-ESP-IDF app that links **esp_rtl_sdr** and exercises the public 0.7.11 drop-in
+ESP-IDF app that links **esp_rtl_sdr** and exercises the public 0.7.12 drop-in
 contract on ESP32-P4 / Tab5.
 
 **One USB host install per boot.** IDF 5.5.4 `usb_host_uninstall` is not a
@@ -15,8 +15,13 @@ not two installs in one run.
 | overlay | `CONFIG_ESP_RTL_SDR_SMOKE_URB_3X32K` | 3 x 32768 | `usb_soak_960k_3x32k` |
 
 Quiet soak: BOTH + auto ring, drain via `read()` on a helper task, no
-gain/AGC/bias during the window, 960 kS/s, 8 s default. PASS only if
-efficiency >= 90%. Then the L4 gain / Tuner AUTO / RTL AGC / `read()` matrix.
+gain/AGC/bias during the window, 960 kS/s, 8 s default. After `first_read`
+the stream is stopped and started again on the **same USB host install** so
+SOAK bytes/overruns/drops/advice are the drain window, not the 400 ms
+undrained wait. PASS if scoped efficiency >= 90%, delta overruns == 0,
+delta consumer drops == 0, scoped advice not `USB_STARVING` or
+`APP_TOO_SLOW`, and IQ continues. Then the L4 gain / Tuner AUTO / RTL AGC /
+`read()` matrix.
 
 IQ `EVT_IQ_BLOCK` logging is suppressed so serial cannot stall delivery.
 
@@ -24,7 +29,7 @@ IQ `EVT_IQ_BLOCK` logging is suppressed so serial cannot stall delivery.
 
 ```text
 SMOKE <name> PASS|FAIL
-SOAK <label> eff=<pct> sps=<n> bytes=<n> over=<n> drops=<n> short=<n> urbs=<c>x<b>
+SOAK <label> eff=<pct> sps=<n> bytes=<n> over=<n> drops=<n> short=<n> urbs=<c>x<b> advice=<s> window_ms=<ms>
 SMOKE OVERALL PASS|FAIL passed=<n> failed=<n> hardware=RUN|SKIP
 ```
 
@@ -46,7 +51,7 @@ selects min_rev 3.1 and esptool refuses: bootloader requires [v3.1-v3.99], chip 
 These symbols are **this example only**. They do not ship in the library. P4 rev
 <3.0 vs >=3.0 firmware is mutually exclusive; a v3.1+ module must not use this default.
 
-`CMakeLists.txt` sets `PROJECT_VER` to `0.7.11` so the image identity matches the
+`CMakeLists.txt` sets `PROJECT_VER` to `0.7.12` so the image identity matches the
 driver, not git-describe of an older tag.
 
 ## Build (ESP32-P4, IDF 5.5.4)
@@ -69,9 +74,9 @@ idf.py -B build-3x32k build
 # Tab5: idf.py -B build-3x32k -p COM17 flash monitor
 ```
 
-Confirm at boot: `esp_rtl_sdr 0.7.11 soak=usb_soak_960k_6x16k urbs=6x16384`
+Confirm at boot: `esp_rtl_sdr 0.7.12 soak=usb_soak_960k_6x16k urbs=6x16384`
 or `soak=usb_soak_960k_3x32k urbs=3x32768`. App version in
-`build/project_description.json` must be `0.7.11`.
+`build/project_description.json` must be `0.7.12`.
 
 The component is pulled via `components/esp_rtl_sdr/` (stable name wrapping the
 repo root sources). No dongle is required for a successful **compile**.

--- a/examples/p4_serial_smoke/main/main.c
+++ b/examples/p4_serial_smoke/main/main.c
@@ -1,5 +1,5 @@
 /*
- * ESP-IDF Tab5 / P4 drop-in smoke for esp_rtl_sdr public API (v0.7.11).
+ * ESP-IDF Tab5 / P4 drop-in smoke for esp_rtl_sdr public API (v0.7.12).
  *
  * One USB host install per boot. URB layout is a Kconfig choice so A/B
  * (6x16 KiB vs 3x32 KiB) is two firmware images, not two installs.
@@ -7,9 +7,12 @@
  * Quiet soak: BOTH + auto ring, drain via read() on a helper task, no
  * mid-stream EP0, then L4 gain / AUTO / RTL AGC matrix.
  *
+ * SOAK bytes/over/drops/advice are the 8 s drain window (stream restart
+ * after first_read), not cumulative pre-soak pull-ring overflow.
+ *
  * Grep-friendly rows:
  *   SMOKE <name> PASS|FAIL
- *   SOAK <label> eff=<pct> sps=<n> bytes=<n> over=<n> drops=<n> short=<n> urbs=<c>x<b>
+ *   SOAK <label> eff=<pct> sps=<n> bytes=<n> over=<n> drops=<n> short=<n> urbs=<c>x<b> advice=<s> window_ms=<ms>
  *   SMOKE OVERALL PASS|FAIL passed=<n> failed=<n> hardware=<RUN|SKIP>
  */
 #include <stdio.h>
@@ -21,6 +24,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "esp_rtl_sdr.h"
+#include "smoke_soak_scope.h"
 
 static const char *TAG = "esp_rtl_sdr_smoke";
 
@@ -127,7 +131,7 @@ static void check_pure_helpers(void)
     smoke_row("rate_4M_reject", !esp_rtl_sdr_is_rate_supported(4000000));
 
     const char *ver = esp_rtl_sdr_get_version_string();
-    smoke_row("version_0_7_11", ver != NULL && strcmp(ver, "0.7.11") == 0);
+    smoke_row("version_0_7_12", ver != NULL && strcmp(ver, "0.7.12") == 0);
 
     const uint32_t caps = esp_rtl_sdr_get_capabilities();
     smoke_row("cap_gain", (caps & ESP_RTL_SDR_CAP_GAIN) != 0);
@@ -208,11 +212,31 @@ static void run_l4_matrix(esp_rtl_sdr_handle_t sdr)
     smoke_read(sdr, "manual_restore_read");
 }
 
-static void run_quiet_soak(esp_rtl_sdr_handle_t sdr)
+static bool restart_stream_for_soak(esp_rtl_sdr_handle_t sdr,
+                                    const esp_rtl_sdr_stream_config_t *stream)
 {
-    esp_rtl_sdr_metrics_t before;
-    memset(&before, 0, sizeof(before));
-    (void)esp_rtl_sdr_get_metrics(sdr, &before);
+    const esp_err_t stop_err = esp_rtl_sdr_stop(sdr, 1000);
+    if (stop_err != ESP_OK) {
+        ESP_LOGE(TAG, "soak restart stop -> %s", esp_rtl_sdr_err_to_name(stop_err));
+        return false;
+    }
+    const esp_err_t start_err = esp_rtl_sdr_start(sdr, stream);
+    if (start_err != ESP_OK) {
+        ESP_LOGE(TAG, "soak restart start -> %s", esp_rtl_sdr_err_to_name(start_err));
+        return false;
+    }
+    return true;
+}
+
+static void run_quiet_soak(esp_rtl_sdr_handle_t sdr,
+                           const esp_rtl_sdr_stream_config_t *stream)
+{
+    /* first_read waits 400 ms with no consumer. Restart on this same install
+     * so the soak window is not the filled pull ring (v0.7.11 logs). */
+    if (stream == NULL || !restart_stream_for_soak(sdr, stream)) {
+        smoke_row(SMOKE_SOAK_NAME, false);
+        return;
+    }
 
     g_drain = true;
     if (xTaskCreate(drain_task, "soak_drain", 4096, sdr, 5, NULL) != pdPASS) {
@@ -221,32 +245,34 @@ static void run_quiet_soak(esp_rtl_sdr_handle_t sdr)
         return;
     }
 
+    esp_rtl_sdr_metrics_t before;
+    memset(&before, 0, sizeof(before));
+    (void)esp_rtl_sdr_get_metrics(sdr, &before);
+
     settle_ms(CONFIG_ESP_RTL_SDR_SMOKE_SOAK_MS);
+
+    esp_rtl_sdr_metrics_t after;
+    memset(&after, 0, sizeof(after));
+    (void)esp_rtl_sdr_get_metrics(sdr, &after);
     g_drain = false;
     settle_ms(80);
 
-    esp_rtl_sdr_metrics_t after;
-    esp_rtl_sdr_health_info_t health;
-    memset(&after, 0, sizeof(after));
-    memset(&health, 0, sizeof(health));
-    (void)esp_rtl_sdr_get_metrics(sdr, &after);
-    (void)esp_rtl_sdr_get_health(sdr, &health);
+    smoke_soak_scope_t scope;
+    memset(&scope, 0, sizeof(scope));
+    smoke_soak_scope_from_metrics(&before, &after, CONFIG_ESP_RTL_SDR_SMOKE_SOAK_MS,
+                                  stream->sample_rate_sps, &scope);
 
-    const int eff_pct = (int)(health.efficiency * 100.0f + 0.5f);
-    printf("SOAK %s eff=%d sps=%u bytes=%llu over=%u drops=%u short=%u urbs=%ux%u advice=%s\n",
-           SMOKE_SOAK_NAME, eff_pct, (unsigned)after.effective_sps,
-           (unsigned long long)after.bytes_total, (unsigned)after.overruns,
-           (unsigned)after.consumer_drops, (unsigned)after.short_transfers,
-           SMOKE_XFER_COUNT, SMOKE_XFER_BYTES, health.advice);
-    ESP_LOGI(TAG, "soak overall=%d eff=%.3f programmed=%u delta_bytes=%llu",
-             (int)health.overall, (double)health.efficiency,
-             (unsigned)health.programmed_sps,
-             (unsigned long long)(after.bytes_total - before.bytes_total));
+    printf("SOAK %s eff=%d sps=%u bytes=%llu over=%u drops=%u short=%u urbs=%ux%u advice=%s window_ms=%d\n",
+           SMOKE_SOAK_NAME, scope.eff_pct, (unsigned)scope.scoped_sps,
+           (unsigned long long)scope.delta_bytes, (unsigned)scope.delta_overruns,
+           (unsigned)scope.delta_consumer_drops, (unsigned)scope.delta_short_transfers,
+           SMOKE_XFER_COUNT, SMOKE_XFER_BYTES, scope.advice,
+           CONFIG_ESP_RTL_SDR_SMOKE_SOAK_MS);
+    ESP_LOGI(TAG, "soak scoped eff=%.3f delta_bytes=%llu cum_drops=%u->%u",
+             (double)scope.efficiency, (unsigned long long)scope.delta_bytes,
+             (unsigned)before.consumer_drops, (unsigned)after.consumer_drops);
 
-    const bool ok = (after.bytes_total > before.bytes_total) &&
-                    (health.efficiency >= 0.90f) &&
-                    (health.overall != ESP_RTL_SDR_HEALTH_USB_STARVING);
-    smoke_row(SMOKE_SOAK_NAME, ok);
+    smoke_row(SMOKE_SOAK_NAME, scope.pass);
 }
 
 void app_main(void)
@@ -289,7 +315,7 @@ void app_main(void)
         if (start_err == ESP_OK) {
             settle_ms(400);
             smoke_read(sdr, "first_read");
-            run_quiet_soak(sdr);
+            run_quiet_soak(sdr, &stream);
             run_l4_matrix(sdr);
 
             esp_rtl_sdr_metrics_t metrics;

--- a/examples/p4_serial_smoke/main/smoke_soak_scope.h
+++ b/examples/p4_serial_smoke/main/smoke_soak_scope.h
@@ -1,0 +1,86 @@
+/*
+ * Pure soak-window scoring for p4_serial_smoke.
+ * Driver get_health()/get_metrics() are cumulative from stream start; the SOAK
+ * row must use before/after deltas for the drain window only.
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "esp_rtl_sdr.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    uint64_t delta_bytes;
+    uint32_t delta_overruns;
+    uint32_t delta_consumer_drops;
+    uint32_t delta_short_transfers;
+    uint32_t scoped_sps;
+    int eff_pct;
+    float efficiency;
+    const char *advice;
+    bool pass;
+} smoke_soak_scope_t;
+
+/* CU8: samples = bytes/2; sps = bytes * 500 / window_ms (same as the driver). */
+static inline uint32_t smoke_soak_scoped_sps(uint64_t delta_bytes, uint32_t window_ms)
+{
+    if (window_ms == 0) {
+        return 0;
+    }
+    return (uint32_t)((delta_bytes * 500ull) / (uint64_t)window_ms);
+}
+
+static inline void smoke_soak_scope_from_metrics(const esp_rtl_sdr_metrics_t *before,
+                                                 const esp_rtl_sdr_metrics_t *after,
+                                                 uint32_t window_ms,
+                                                 uint32_t programmed_sps,
+                                                 smoke_soak_scope_t *out)
+{
+    smoke_soak_scope_t z;
+    if (out == NULL) {
+        return;
+    }
+    memset(&z, 0, sizeof(z));
+    z.advice = "invalid";
+    z.pass = false;
+
+    if (before == NULL || after == NULL || window_ms == 0 || programmed_sps == 0) {
+        *out = z;
+        return;
+    }
+
+    z.delta_bytes = after->bytes_total - before->bytes_total;
+    z.delta_overruns = after->overruns - before->overruns;
+    z.delta_consumer_drops = after->consumer_drops - before->consumer_drops;
+    z.delta_short_transfers = after->short_transfers - before->short_transfers;
+    z.scoped_sps = smoke_soak_scoped_sps(z.delta_bytes, window_ms);
+    z.eff_pct = (int)(((uint64_t)z.scoped_sps * 100ull) / (uint64_t)programmed_sps);
+    z.efficiency = (float)z.scoped_sps / (float)programmed_sps;
+    const bool eff_ok = z.eff_pct >= 90;
+
+    if (!eff_ok) {
+        z.advice = "USB_STARVING";
+    } else if (z.delta_consumer_drops > 0) {
+        z.advice = "APP_TOO_SLOW";
+    } else {
+        z.advice = "ok";
+    }
+
+    const bool continuing_iq = z.delta_bytes > 0;
+    const bool advice_ok =
+        (strcmp(z.advice, "USB_STARVING") != 0) && (strcmp(z.advice, "APP_TOO_SLOW") != 0);
+    z.pass = continuing_iq && eff_ok && (z.delta_overruns == 0) &&
+             (z.delta_consumer_drops == 0) && advice_ok;
+    *out = z;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/examples/p4_serial_smoke/sdkconfig.defaults.urb_3x32k
+++ b/examples/p4_serial_smoke/sdkconfig.defaults.urb_3x32k
@@ -1,4 +1,7 @@
 # Overlay: select 3x32 KiB URB layout for this image.
-# Use with: idf.py -D SDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.defaults.urb_3x32k" set-target esp32p4
+# Use with a dedicated -B dir AND SDKCONFIG (IDF 5.5.4 -B does not isolate
+# sdkconfig by itself):
+#   idf.py -B build-3x32k -D SDKCONFIG=build-3x32k/sdkconfig ^
+#     -D SDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.defaults.urb_3x32k" set-target esp32p4
 # CONFIG_ESP_RTL_SDR_SMOKE_URB_6X16K is not set
 CONFIG_ESP_RTL_SDR_SMOKE_URB_3X32K=y

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,5 +1,5 @@
 ## esp_rtl_sdr — ESP Component Registry metadata
-version: "0.7.11"
+version: "0.7.12"
 description: >
   Clean-room ESP-IDF USB Host client for RTL2832U-class SDR dongles.
   Blog V4 (R828D) profile first; profile-based expansion for other tuners.

--- a/include/esp_rtl_sdr.h
+++ b/include/esp_rtl_sdr.h
@@ -87,7 +87,7 @@ extern "C" {
 /** Semantic version of this public header / binary API. */
 #define ESP_RTL_SDR_VERSION_MAJOR 0
 #define ESP_RTL_SDR_VERSION_MINOR 7
-#define ESP_RTL_SDR_VERSION_PATCH 11
+#define ESP_RTL_SDR_VERSION_PATCH 12
 
 #define ESP_RTL_SDR_VERSION_NUMBER                                      \
     ((ESP_RTL_SDR_VERSION_MAJOR * 10000) +                              \

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "esp_rtl_sdr",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "description": "Clean-room ESP USB Host client for RTL2832U-class SDR (Blog V4 profile first)",
   "keywords": "sdr, rtl-sdr, rtl2832u, usb, esp32-p4, esp_rtl_sdr",
   "license": "AGPL-3.0-only",

--- a/tests/host/CMakeLists.txt
+++ b/tests/host/CMakeLists.txt
@@ -14,6 +14,7 @@ target_include_directories(esp_rtl_sdr_host_tests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/stubs
     ${CMAKE_CURRENT_SOURCE_DIR}/../../include
     ${CMAKE_CURRENT_SOURCE_DIR}/../../private
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../examples/p4_serial_smoke/main
 )
 
 if(MSVC)

--- a/tests/host/test_policy.cpp
+++ b/tests/host/test_policy.cpp
@@ -13,6 +13,7 @@
 #include "esp_rtl_sdr.h"
 #include "measured_gain_bias_v4.hpp"
 #include "reentrancy.hpp"
+#include "smoke_soak_scope.h"
 
 static int g_failed = 0;
 static int g_passed = 0;
@@ -525,6 +526,81 @@ static void test_error_base_unique(void)
     EXPECT_EQ_I(ESP_RTL_SDR_ERR_UNSUPPORTED_DEVICE, ESP_RTL_SDR_ERR_NOT_V4);
 }
 
+static void test_smoke_soak_scope(void)
+{
+    const uint32_t window_ms = 8000;
+    const uint32_t sps = 960000;
+    const uint64_t eight_sec_cu8 = (uint64_t)sps * 2ull * (window_ms / 1000u);
+
+    esp_rtl_sdr_metrics_t before;
+    esp_rtl_sdr_metrics_t after;
+    smoke_soak_scope_t scope;
+
+    /* v0.7.11 6x16k artifact: 507904 pre-soak drops must not fail a clean drain. */
+    std::memset(&before, 0, sizeof(before));
+    std::memset(&after, 0, sizeof(after));
+    before.consumer_drops = 507904;
+    before.bytes_total = 400000;
+    after.consumer_drops = 507904;
+    after.overruns = 0;
+    after.bytes_total = before.bytes_total + eight_sec_cu8;
+    std::memset(&scope, 0, sizeof(scope));
+    smoke_soak_scope_from_metrics(&before, &after, window_ms, sps, &scope);
+    EXPECT_EQ_U(scope.delta_consumer_drops, 0u);
+    EXPECT_EQ_U(scope.delta_overruns, 0u);
+    EXPECT_TRUE(scope.delta_bytes == eight_sec_cu8);
+    EXPECT_EQ_U(scope.scoped_sps, sps);
+    EXPECT_EQ_I(scope.eff_pct, 100);
+    EXPECT_STREQ(scope.advice, "ok");
+    EXPECT_TRUE(scope.pass);
+
+    /* v0.7.11 3x32k artifact: 593920 cumulative drops, zero delta. */
+    before.consumer_drops = 593920;
+    after.consumer_drops = 593920;
+    smoke_soak_scope_from_metrics(&before, &after, window_ms, sps, &scope);
+    EXPECT_EQ_U(scope.delta_consumer_drops, 0u);
+    EXPECT_TRUE(scope.pass);
+
+    /* Genuine scoped drops stay visible. */
+    after.consumer_drops = 593920 + 16384;
+    smoke_soak_scope_from_metrics(&before, &after, window_ms, sps, &scope);
+    EXPECT_EQ_U(scope.delta_consumer_drops, 16384u);
+    EXPECT_STREQ(scope.advice, "APP_TOO_SLOW");
+    EXPECT_TRUE(!scope.pass);
+
+    /* Scoped overruns fail even when drops are unchanged. */
+    after.consumer_drops = before.consumer_drops;
+    after.overruns = 3;
+    smoke_soak_scope_from_metrics(&before, &after, window_ms, sps, &scope);
+    EXPECT_EQ_U(scope.delta_overruns, 3u);
+    EXPECT_TRUE(!scope.pass);
+
+    /* 90% of programmed CU8 in 8 s meets the efficiency bar. */
+    after.overruns = 0;
+    after.bytes_total = before.bytes_total + (eight_sec_cu8 * 90ull) / 100ull;
+    smoke_soak_scope_from_metrics(&before, &after, window_ms, sps, &scope);
+    EXPECT_EQ_I(scope.eff_pct, 90);
+    EXPECT_STREQ(scope.advice, "ok");
+    EXPECT_TRUE(scope.pass);
+
+    /* 89% of programmed CU8 in 8 s is USB_STARVING. */
+    after.bytes_total = before.bytes_total + (eight_sec_cu8 * 89ull) / 100ull;
+    smoke_soak_scope_from_metrics(&before, &after, window_ms, sps, &scope);
+    EXPECT_EQ_I(scope.eff_pct, 89);
+    EXPECT_STREQ(scope.advice, "USB_STARVING");
+    EXPECT_TRUE(!scope.pass);
+
+    /* No IQ in the window fails even if advice tokens are unused. */
+    after.bytes_total = before.bytes_total;
+    smoke_soak_scope_from_metrics(&before, &after, window_ms, sps, &scope);
+    EXPECT_TRUE(scope.delta_bytes == 0);
+    EXPECT_TRUE(!scope.pass);
+
+    smoke_soak_scope_from_metrics(nullptr, &after, window_ms, sps, &scope);
+    EXPECT_STREQ(scope.advice, "invalid");
+    EXPECT_TRUE(!scope.pass);
+}
+
 int main(void)
 {
     std::printf("esp_rtl_sdr host policy tests (%s)\n", esp_rtl_sdr_get_version_string());
@@ -541,6 +617,7 @@ int main(void)
     test_passport_opts();
     test_usb_identity_constants();
     test_error_base_unique();
+    test_smoke_soak_scope();
     std::printf("RESULT passed=%d failed=%d\n", g_passed, g_failed);
     return g_failed == 0 ? 0 : 1;
 }

--- a/tests/host/test_policy.cpp
+++ b/tests/host/test_policy.cpp
@@ -8,6 +8,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <fstream>
 #include <string>
 
 #include "esp_rtl_sdr.h"
@@ -601,6 +602,46 @@ static void test_smoke_soak_scope(void)
     EXPECT_TRUE(!scope.pass);
 }
 
+static std::string slurp_repo_file(const char *rel)
+{
+    std::string here(__FILE__);
+    const auto slash = here.find_last_of("/\\");
+    const std::string host_dir =
+        (slash == std::string::npos) ? std::string(".") : here.substr(0, slash);
+    const std::string path = host_dir + "/../../" + rel;
+    std::ifstream in(path.c_str());
+    if (!in) {
+        return std::string();
+    }
+    return std::string((std::istreambuf_iterator<char>(in)),
+                       std::istreambuf_iterator<char>());
+}
+
+static void test_smoke_urb_image_isolation(void)
+{
+    const std::string cmake = slurp_repo_file("examples/p4_serial_smoke/CMakeLists.txt");
+    EXPECT_TRUE(cmake.find("SDKCONFIG") != std::string::npos);
+    EXPECT_TRUE(cmake.find("CMAKE_BINARY_DIR") != std::string::npos);
+
+    const std::string base_defaults =
+        slurp_repo_file("examples/p4_serial_smoke/sdkconfig.defaults");
+    EXPECT_TRUE(!base_defaults.empty());
+    EXPECT_TRUE(base_defaults.find("CONFIG_ESP_RTL_SDR_SMOKE_URB_3X32K") ==
+                std::string::npos);
+
+    const std::string overlay =
+        slurp_repo_file("examples/p4_serial_smoke/sdkconfig.defaults.urb_3x32k");
+    EXPECT_TRUE(overlay.find("CONFIG_ESP_RTL_SDR_SMOKE_URB_3X32K=y") !=
+                std::string::npos);
+
+    const std::string readme = slurp_repo_file("examples/p4_serial_smoke/README.md");
+    EXPECT_TRUE(readme.find("build-6x16k") != std::string::npos);
+    EXPECT_TRUE(readme.find("build-3x32k") != std::string::npos);
+    EXPECT_TRUE(readme.find("-D SDKCONFIG=build-6x16k/sdkconfig") != std::string::npos);
+    EXPECT_TRUE(readme.find("-D SDKCONFIG=build-3x32k/sdkconfig") != std::string::npos);
+    EXPECT_TRUE(readme.find("CONFIG_ESP_RTL_SDR_SMOKE_URB_3X32K") != std::string::npos);
+}
+
 int main(void)
 {
     std::printf("esp_rtl_sdr host policy tests (%s)\n", esp_rtl_sdr_get_version_string());
@@ -618,6 +659,7 @@ int main(void)
     test_usb_identity_constants();
     test_error_base_unique();
     test_smoke_soak_scope();
+    test_smoke_urb_image_isolation();
     std::printf("RESULT passed=%d failed=%d\n", g_passed, g_failed);
     return g_failed == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Summary
- Correct the `p4_serial_smoke` SOAK evidence boundary: v0.7.11 printed cumulative `consumer_drops` after a 400 ms undrained wait before `first_read`. Those Tab5 counts (507904 @ 6x16384, 593920 @ 3x32768) match pre-soak pull-ring overflow, not the 8 s drain.
- Same USB host install; stream restart + scoped/delta bytes, overruns, drops, and advice. PASS requires efficiency >= 90%, delta overruns == 0, delta consumer drops == 0, advice not `USB_STARVING` or `APP_TOO_SLOW`, continuing IQ, and overall hardware PASS.
- Public version 0.7.12. Smoke harness only; driver streaming engine unchanged.
- **No hardware soak has been run against this tree.**
- **Tag `v0.7.11` remains immutable.** Do not rewrite it.

Human: Erik (direction, release). Implementation: Grok Build. Independent review and IDF 5.5.4 native A/B builds: Codex.

## Evidence (Codex, this branch)
- [x] `tests\scripts\run_host_tests.ps1` → `RESULT passed=249 failed=0`, `HOST_TESTS_OK`
- [x] `bash tests/scripts/check_truth_hygiene.sh` → `TRUTH_HYGIENE_OK ver=0.7.12`
- [x] `git diff --check` → clean
- [x] ESP-IDF 5.5.4 native default 6x16384 build → success, `project_version` 0.7.12
- [x] ESP-IDF 5.5.4 native overlay 3x32768 build → success, `project_version` 0.7.12
- Pre-existing volatile ++/-- warnings only in unchanged `src/esp_rtl_sdr.cpp`

## Test plan (Tab5 operator, after merge/tag — not this PR)
- [ ] Flash both images on COM17 from tag `v0.7.12` (`docs/V0_7_12_TAB5_HANDOFF.md`)
- [ ] Confirm SOAK rows use scoped/delta drops=0 (or fail honestly), not v0.7.11 cumulative artifacts
- [ ] Restore OrcSDR when done

Do not merge this PR from the agent session. Do not create or rewrite tags or GitHub Releases here.