### PR TITLE
fix(smoke): power Tab5 USB-A before enumeration

### DIFF
--- a/docs/V0_7_12_TAB5_HANDOFF.md
+++ b/docs/V0_7_12_TAB5_HANDOFF.md
@@ -54,8 +54,8 @@ idf.py -B build-3x32k -p COM17 flash monitor
 
 Boot must print `esp_rtl_sdr 0.7.12 soak=usb_soak_960k_6x16k urbs=6x16384`
 or `... soak=usb_soak_960k_3x32k urbs=3x32768`.
-It must also print `SMOKE tab5_usb_power PASS`; the example initializes
-M5Unified and enables the Tab5 USB-A rail before driver installation.
+It must also print `SMOKE tab5_usb_power PASS`; the example uses M5Unified's
+power-expander helper to enable the Tab5 USB-A rail before driver installation.
 
 ## Pass criteria (each image)
 

--- a/docs/V0_7_12_TAB5_HANDOFF.md
+++ b/docs/V0_7_12_TAB5_HANDOFF.md
@@ -54,6 +54,8 @@ idf.py -B build-3x32k -p COM17 flash monitor
 
 Boot must print `esp_rtl_sdr 0.7.12 soak=usb_soak_960k_6x16k urbs=6x16384`
 or `... soak=usb_soak_960k_3x32k urbs=3x32768`.
+It must also print `SMOKE tab5_usb_power PASS`; the example initializes
+M5Unified and enables the Tab5 USB-A rail before driver installation.
 
 ## Pass criteria (each image)
 

--- a/examples/p4_serial_smoke/README.md
+++ b/examples/p4_serial_smoke/README.md
@@ -3,8 +3,9 @@
 ESP-IDF app that links **esp_rtl_sdr** and exercises the public 0.7.12 drop-in
 contract on ESP32-P4 / Tab5.
 
-The example initializes M5Unified and enables the Tab5 USB-A power rail before
-installing the USB host, so cold boots do not depend on previously run firmware.
+The example uses M5Unified's Tab5 power-expander helper to enable the USB-A rail
+before installing the USB host, so cold boots do not depend on previously run
+firmware or initialize unrelated display/audio hardware.
 
 **One USB host install per boot.** IDF 5.5.4 `usb_host_uninstall` is not a
 reliable re-entry on Tab5, so A/B URB layouts are **two firmware images**,

--- a/examples/p4_serial_smoke/README.md
+++ b/examples/p4_serial_smoke/README.md
@@ -3,6 +3,9 @@
 ESP-IDF app that links **esp_rtl_sdr** and exercises the public 0.7.12 drop-in
 contract on ESP32-P4 / Tab5.
 
+The example initializes M5Unified and enables the Tab5 USB-A power rail before
+installing the USB host, so cold boots do not depend on previously run firmware.
+
 **One USB host install per boot.** IDF 5.5.4 `usb_host_uninstall` is not a
 reliable re-entry on Tab5, so A/B URB layouts are **two firmware images**,
 not two installs in one run.

--- a/examples/p4_serial_smoke/main/CMakeLists.txt
+++ b/examples/p4_serial_smoke/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
-    SRCS "main.c"
+    SRCS "main.cpp"
     INCLUDE_DIRS "."
-    REQUIRES esp_rtl_sdr nvs_flash
+    REQUIRES esp_rtl_sdr m5unified nvs_flash
 )

--- a/examples/p4_serial_smoke/main/idf_component.yml
+++ b/examples/p4_serial_smoke/main/idf_component.yml
@@ -1,0 +1,3 @@
+dependencies:
+  m5stack/m5unified:
+    version: "0.2.20"

--- a/examples/p4_serial_smoke/main/main.cpp
+++ b/examples/p4_serial_smoke/main/main.cpp
@@ -23,6 +23,7 @@
 #include "nvs_flash.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "M5Unified.h"
 #include "esp_rtl_sdr.h"
 #include "smoke_soak_scope.h"
 
@@ -65,7 +66,7 @@ static void on_event(esp_rtl_sdr_event_t event, const void *payload, void *ctx)
         return;
     }
     if (event == ESP_RTL_SDR_EVT_PASSPORT_PROGRESS && payload != NULL) {
-        const esp_rtl_sdr_passport_entry_t *e = payload;
+        const auto *e = static_cast<const esp_rtl_sdr_passport_entry_t *>(payload);
         ESP_LOGI(TAG, "passport progress rate=%u eff=%u stable=%d",
                  (unsigned)e->exact_sps, (unsigned)e->effective_sps, (int)e->stable);
     }
@@ -74,6 +75,30 @@ static void on_event(esp_rtl_sdr_event_t event, const void *payload, void *ctx)
 static void settle_ms(int ms)
 {
     vTaskDelay(pdMS_TO_TICKS(ms));
+}
+
+static bool enable_tab5_usb_power(void)
+{
+    auto config = M5.config();
+    config.clear_display = false;
+    config.external_display_value = 0;
+    config.external_speaker_value = 0;
+    config.internal_imu = false;
+    config.internal_rtc = false;
+    config.internal_mic = false;
+    config.internal_spk = false;
+    config.output_power = true;
+    M5.begin(config);
+
+    if (M5.getBoard() != m5::board_t::board_M5Tab5) {
+        ESP_LOGE(TAG, "expected Tab5, detected board=%u", (unsigned)M5.getBoard());
+        return false;
+    }
+
+    M5.Power.setExtOutput(true, m5::ext_USB);
+    settle_ms(350);
+    ESP_LOGI(TAG, "Tab5 USB-A power enabled and settled");
+    return true;
 }
 
 static bool smoke_read(esp_rtl_sdr_handle_t sdr, const char *name)
@@ -275,13 +300,14 @@ static void run_quiet_soak(esp_rtl_sdr_handle_t sdr,
     smoke_row(SMOKE_SOAK_NAME, scope.pass);
 }
 
-void app_main(void)
+extern "C" void app_main(void)
 {
     ESP_ERROR_CHECK(nvs_flash_init());
     ESP_LOGI(TAG, "esp_rtl_sdr %s soak=%s urbs=%ux%u",
              esp_rtl_sdr_get_version_string(), SMOKE_SOAK_NAME,
              SMOKE_XFER_COUNT, SMOKE_XFER_BYTES);
     check_pure_helpers();
+    smoke_row("tab5_usb_power", enable_tab5_usb_power());
 
     esp_rtl_sdr_config_t cfg;
     esp_rtl_sdr_config_default(&cfg);

--- a/examples/p4_serial_smoke/main/main.cpp
+++ b/examples/p4_serial_smoke/main/main.cpp
@@ -23,7 +23,7 @@
 #include "nvs_flash.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "M5Unified.h"
+#include "utility/PI4IOE5V6408_Class.hpp"
 #include "esp_rtl_sdr.h"
 #include "smoke_soak_scope.h"
 
@@ -79,26 +79,26 @@ static void settle_ms(int ms)
 
 static bool enable_tab5_usb_power(void)
 {
-    auto config = M5.config();
-    config.clear_display = false;
-    config.external_display_value = 0;
-    config.external_speaker_value = 0;
-    config.internal_imu = false;
-    config.internal_rtc = false;
-    config.internal_mic = false;
-    config.internal_spk = false;
-    config.output_power = true;
-    M5.begin(config);
-
-    if (M5.getBoard() != m5::board_t::board_M5Tab5) {
-        ESP_LOGE(TAG, "expected Tab5, detected board=%u", (unsigned)M5.getBoard());
+    if (!m5::In_I2C.begin(I2C_NUM_1, GPIO_NUM_31, GPIO_NUM_32)) {
+        ESP_LOGE(TAG, "Tab5 internal I2C initialization failed");
         return false;
     }
 
-    M5.Power.setExtOutput(true, m5::ext_USB);
+    m5::PI4IOE5V6408_Class power_io(0x44);
+    if (!power_io.begin()) {
+        ESP_LOGE(TAG, "Tab5 power expander not found");
+        return false;
+    }
+
+    power_io.digitalWrite(3, true);
+    power_io.setHighImpedance(3, false);
+    power_io.setPullMode(3, true);
+    power_io.enablePull(3, true);
+    power_io.setDirection(3, false);
     settle_ms(350);
-    ESP_LOGI(TAG, "Tab5 USB-A power enabled and settled");
-    return true;
+    const bool enabled = power_io.getWriteValue(3);
+    ESP_LOGI(TAG, "Tab5 USB-A power %s and settled", enabled ? "enabled" : "failed");
+    return enabled;
 }
 
 static bool smoke_read(esp_rtl_sdr_handle_t sdr, const char *name)


### PR DESCRIPTION
## Summary
- initialize M5Unified in the Tab5 smoke example
- enable the Tab5 USB-A power rail before USB host installation
- document the new boot proof row

## Verification
- ESP-IDF 5.5.4 default 6x16 KiB build: PASS
- ESP-IDF 5.5.4 overlay 3x32 KiB build: PASS
- hardware verification on COM17: pending

Addresses #14