### PR TITLE
feat(0.7.13): windowed metrics/health from metric snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## 0.7.13 (2026-09-05)
+
+### Added
+
+- **Public windowed metrics/health from metric snapshots:** apps take two
+  sp_rtl_sdr_get_metrics() snapshots and call sp_rtl_sdr_metrics_delta() /
+  sp_rtl_sdr_health_from_window() for scoped bytes, overruns, consumer drops,
+  short transfers, effective SPS, efficiency, and USB health
+  (OK / USB_STARVING / APP_TOO_SLOW) for that window only. Pure helpers
+  (no new handle mutex state). get_health() remains lifetime/cumulative from
+  stream start so early pull-ring overflow is not mistaken for soak drops.
+  p4_serial_smoke soak scoring now wraps the public helpers.
+
 ## 0.7.12 (2026-08-27)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 ### Added
 
 - **Public windowed metrics/health from metric snapshots:** apps take two
-  sp_rtl_sdr_get_metrics() snapshots and call sp_rtl_sdr_metrics_delta() /
-  sp_rtl_sdr_health_from_window() for scoped bytes, overruns, consumer drops,
+  esp_rtl_sdr_get_metrics() snapshots and call esp_rtl_sdr_metrics_delta() /
+  esp_rtl_sdr_health_from_window() for scoped bytes, overruns, consumer drops,
   short transfers, effective SPS, efficiency, and USB health
   (OK / USB_STARVING / APP_TOO_SLOW) for that window only. Pure helpers
   (no new handle mutex state). get_health() remains lifetime/cumulative from

--- a/PROJECT_TRUTH.md
+++ b/PROJECT_TRUTH.md
@@ -6,8 +6,8 @@ wins for *what is true right now*.
 Same discipline as [TheOrc PROJECT_TRUTH](https://github.com/hardcoreerik/TheOrc):
 claims need evidence labels; oversell is a bug; retract rather than spin.
 
-Snapshot date: **2026-08-27**  
-Version: **0.7.12** (smoke SOAK row is the 8 s drain window; USB soak still operator work — not production-ready)
+Snapshot date: **2026-09-05**  
+Version: **0.7.13** (public windowed metrics/health; smoke SOAK wraps it; USB soak still operator work - not production-ready)
 Local repo: `F:\Ai\ESP_RTL_SDR\`  
 Remote: **https://github.com/hardcoreerik/esp-rtl-sdr**  
 Open-source honesty: [docs/AI_DEVELOPMENT_DISCLOSURE.md](docs/AI_DEVELOPMENT_DISCLOSURE.md) ·
@@ -122,6 +122,7 @@ Product vision: **`docs/VISION.md`**. Silicon / DS map: **`docs/SILICON.md`**.
 | **0.7.10** | Quiet USB soak + Tab5 P4 rev defaults (immutable; soak blocked by #11) |
 | **0.7.11** | Smoke soak_drain 16 KiB buffer off the 4 KiB task stack (#11) |
 | **0.7.12** | Smoke SOAK evidence is scoped to the drain window (not pre-soak ring overflow) |
+| **0.7.13** | Public metrics_delta / health_from_window from metric snapshots (honest soak/app window) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Make an RTL-SDR Blog V4 a first-class peripheral on ESP32-P4** — continuous I/Q over USB Host, with a real embedded driver API.
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
-![Status](https://img.shields.io/badge/version-0.7.12-green)
+![Status](https://img.shields.io/badge/version-0.7.13-green)
 [![GitHub](https://img.shields.io/badge/github-esp--rtl--sdr-black)](https://github.com/hardcoreerik/esp-rtl-sdr)
 ![Target](https://img.shields.io/badge/ESP32--P4-HS_USB-green)
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1151,7 +1151,10 @@ esp_err_t esp_rtl_sdr_get_health(esp_rtl_sdr_handle_t handle,
                                  esp_rtl_sdr_health_info_t *out_health);
 ```
 
-Snapshot from live metrics. Safe while streaming. Use `advice[]` for UI / logs.
+Lifetime/cumulative snapshot from live metrics (stream start). Safe while
+streaming. Use `advice[]` for UI / logs. Early pull-ring overflow remains in these
+counters for the whole stream - for soak / app windows use
+`esp_rtl_sdr_health_from_window()` instead.
 
 ```c
 esp_rtl_sdr_health_info_t h;
@@ -1160,6 +1163,30 @@ if (h.overall != ESP_RTL_SDR_HEALTH_OK) {
     ESP_LOGW(TAG, "health: %s", h.advice);
 }
 ```
+
+### `esp_rtl_sdr_metrics_delta` / `esp_rtl_sdr_health_from_window` (0.7.13+)
+
+Pure helpers (no handle mutex). Take two `esp_rtl_sdr_get_metrics()` snapshots plus
+`window_ms` and programmed SPS:
+
+```c
+esp_rtl_sdr_metrics_t before, after;
+esp_rtl_sdr_metrics_window_t win;
+esp_rtl_sdr_health_info_t wh;
+ESP_ERROR_CHECK(esp_rtl_sdr_get_metrics(sdr, &before));
+/* ... measure window_ms ... */
+ESP_ERROR_CHECK(esp_rtl_sdr_get_metrics(sdr, &after));
+ESP_ERROR_CHECK(esp_rtl_sdr_metrics_delta(&before, &after, window_ms, sps, &win));
+ESP_ERROR_CHECK(esp_rtl_sdr_health_from_window(&before, &after, window_ms, sps, &wh));
+```
+
+| Field / result | Meaning |
+|---|---|
+| `delta_*` | Bytes / overruns / consumer_drops / short_transfers in the window |
+| `effective_sps` | CU8 scoped rate: `delta_bytes * 500 / window_ms` |
+| `efficiency` | `effective_sps / programmed_sps` |
+| `usb` / `overall` | Window only: `OK`, `USB_STARVING` (<90% eff), or `APP_TOO_SLOW` (delta drops) |
+| `rf` | Left `UNKNOWN` (sample swing is not windowed by these counters) |
 
 ### `esp_rtl_sdr_passport_opts_default`
 

--- a/examples/p4_serial_smoke/CMakeLists.txt
+++ b/examples/p4_serial_smoke/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 
-# Pin app version so idf.py project_description is 0.7.12, not git-describe
+# Pin app version so idf.py project_description is 0.7.13, not git-describe
 # of an older tag.
-set(PROJECT_VER "0.7.12")
+set(PROJECT_VER "0.7.13")
 
 # IDF 5.5.4 defaults SDKCONFIG to ${CMAKE_SOURCE_DIR}/sdkconfig. -B only
 # changes the binary dir, so two URB images would share one config. Keep

--- a/examples/p4_serial_smoke/main/main.cpp
+++ b/examples/p4_serial_smoke/main/main.cpp
@@ -1,5 +1,5 @@
 /*
- * ESP-IDF Tab5 / P4 drop-in smoke for esp_rtl_sdr public API (v0.7.12).
+ * ESP-IDF Tab5 / P4 drop-in smoke for esp_rtl_sdr public API (v0.7.13).
  *
  * One USB host install per boot. URB layout is a Kconfig choice so A/B
  * (6x16 KiB vs 3x32 KiB) is two firmware images, not two installs.
@@ -156,7 +156,7 @@ static void check_pure_helpers(void)
     smoke_row("rate_4M_reject", !esp_rtl_sdr_is_rate_supported(4000000));
 
     const char *ver = esp_rtl_sdr_get_version_string();
-    smoke_row("version_0_7_12", ver != NULL && strcmp(ver, "0.7.12") == 0);
+    smoke_row("version_0_7_13", ver != NULL && strcmp(ver, "0.7.13") == 0);
 
     const uint32_t caps = esp_rtl_sdr_get_capabilities();
     smoke_row("cap_gain", (caps & ESP_RTL_SDR_CAP_GAIN) != 0);

--- a/examples/p4_serial_smoke/main/smoke_soak_scope.h
+++ b/examples/p4_serial_smoke/main/smoke_soak_scope.h
@@ -1,7 +1,8 @@
 /*
- * Pure soak-window scoring for p4_serial_smoke.
- * Driver get_health()/get_metrics() are cumulative from stream start; the SOAK
- * row must use before/after deltas for the drain window only.
+ * Thin soak-window adapter for p4_serial_smoke.
+ * Scoring lives in public esp_rtl_sdr_metrics_delta / esp_rtl_sdr_health_from_window
+ * so apps do not reinvent before/after delta math. get_health()/get_metrics() remain
+ * cumulative from stream start; SOAK uses the window helpers only.
  */
 #pragma once
 
@@ -28,15 +29,6 @@ typedef struct {
     bool pass;
 } smoke_soak_scope_t;
 
-/* CU8: samples = bytes/2; sps = bytes * 500 / window_ms (same as the driver). */
-static inline uint32_t smoke_soak_scoped_sps(uint64_t delta_bytes, uint32_t window_ms)
-{
-    if (window_ms == 0) {
-        return 0;
-    }
-    return (uint32_t)((delta_bytes * 500ull) / (uint64_t)window_ms);
-}
-
 static inline void smoke_soak_scope_from_metrics(const esp_rtl_sdr_metrics_t *before,
                                                  const esp_rtl_sdr_metrics_t *after,
                                                  uint32_t window_ms,
@@ -51,31 +43,40 @@ static inline void smoke_soak_scope_from_metrics(const esp_rtl_sdr_metrics_t *be
     z.advice = "invalid";
     z.pass = false;
 
-    if (before == NULL || after == NULL || window_ms == 0 || programmed_sps == 0) {
+    esp_rtl_sdr_metrics_window_t win;
+    esp_rtl_sdr_health_info_t health;
+    memset(&win, 0, sizeof(win));
+    memset(&health, 0, sizeof(health));
+
+    if (esp_rtl_sdr_metrics_delta(before, after, window_ms, programmed_sps, &win) !=
+            ESP_OK ||
+        esp_rtl_sdr_health_from_window(before, after, window_ms, programmed_sps,
+                                       &health) != ESP_OK) {
         *out = z;
         return;
     }
 
-    z.delta_bytes = after->bytes_total - before->bytes_total;
-    z.delta_overruns = after->overruns - before->overruns;
-    z.delta_consumer_drops = after->consumer_drops - before->consumer_drops;
-    z.delta_short_transfers = after->short_transfers - before->short_transfers;
-    z.scoped_sps = smoke_soak_scoped_sps(z.delta_bytes, window_ms);
-    z.eff_pct = (int)(((uint64_t)z.scoped_sps * 100ull) / (uint64_t)programmed_sps);
-    z.efficiency = (float)z.scoped_sps / (float)programmed_sps;
-    const bool eff_ok = z.eff_pct >= 90;
+    z.delta_bytes = win.delta_bytes;
+    z.delta_overruns = win.delta_overruns;
+    z.delta_consumer_drops = win.delta_consumer_drops;
+    z.delta_short_transfers = win.delta_short_transfers;
+    z.scoped_sps = win.effective_sps;
+    z.efficiency = win.efficiency;
+    z.eff_pct = (int)(((uint64_t)win.effective_sps * 100ull) / (uint64_t)programmed_sps);
 
-    if (!eff_ok) {
+    if (health.overall == ESP_RTL_SDR_HEALTH_USB_STARVING) {
         z.advice = "USB_STARVING";
-    } else if (z.delta_consumer_drops > 0) {
+    } else if (health.overall == ESP_RTL_SDR_HEALTH_APP_TOO_SLOW) {
         z.advice = "APP_TOO_SLOW";
-    } else {
+    } else if (health.overall == ESP_RTL_SDR_HEALTH_OK) {
         z.advice = "ok";
+    } else {
+        z.advice = "invalid";
     }
 
     const bool continuing_iq = z.delta_bytes > 0;
-    const bool advice_ok =
-        (strcmp(z.advice, "USB_STARVING") != 0) && (strcmp(z.advice, "APP_TOO_SLOW") != 0);
+    const bool eff_ok = z.eff_pct >= 90;
+    const bool advice_ok = (health.overall == ESP_RTL_SDR_HEALTH_OK);
     z.pass = continuing_iq && eff_ok && (z.delta_overruns == 0) &&
              (z.delta_consumer_drops == 0) && advice_ok;
     *out = z;

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,5 +1,5 @@
 ## esp_rtl_sdr — ESP Component Registry metadata
-version: "0.7.12"
+version: "0.7.13"
 description: >
   Clean-room ESP-IDF USB Host client for RTL2832U-class SDR dongles.
   Blog V4 (R828D) profile first; profile-based expansion for other tuners.

--- a/include/esp_rtl_sdr.h
+++ b/include/esp_rtl_sdr.h
@@ -872,9 +872,10 @@ esp_err_t esp_rtl_sdr_metrics_delta(const esp_rtl_sdr_metrics_t *before,
  * Fills out_health with window deltas in overruns/consumer_drops, scoped
  * effective_sps/efficiency, and usb/overall in {OK, USB_STARVING, APP_TOO_SLOW,
  * UNKNOWN}. RF is left UNKNOWN (sample swing is not windowed by these counters).
- * Priority matches soak scoring: efficiency < 90% -> USB_STARVING; else
- * delta consumer_drops > 0 -> APP_TOO_SLOW; else OK. Delta overruns are reported
- * in overruns but do not alone change the enum (callers may still fail a soak).
+ * Priority matches soak scoring (not get_health()): efficiency < 90% including
+ * 0% -> USB_STARVING; else delta consumer_drops > 0 -> APP_TOO_SLOW (no
+ * drops-vs-overruns tiebreak); else OK. Delta overruns are reported in
+ * overruns but do not alone change the enum (callers may still fail a soak).
  * out_health is not modified on failure.
  *
  * @return ESP_OK, or ESP_ERR_INVALID_ARG if a pointer is NULL / window_ms == 0 /

--- a/include/esp_rtl_sdr.h
+++ b/include/esp_rtl_sdr.h
@@ -87,7 +87,7 @@ extern "C" {
 /** Semantic version of this public header / binary API. */
 #define ESP_RTL_SDR_VERSION_MAJOR 0
 #define ESP_RTL_SDR_VERSION_MINOR 7
-#define ESP_RTL_SDR_VERSION_PATCH 12
+#define ESP_RTL_SDR_VERSION_PATCH 13
 
 #define ESP_RTL_SDR_VERSION_NUMBER                                      \
     ((ESP_RTL_SDR_VERSION_MAJOR * 10000) +                              \
@@ -823,9 +823,68 @@ esp_err_t esp_rtl_sdr_select_device_serial(esp_rtl_sdr_handle_t handle, const ch
  */
 esp_err_t esp_rtl_sdr_apply_need(esp_rtl_sdr_handle_t handle, esp_rtl_sdr_need_t need);
 
-/** Snapshot USB/RF health from live metrics. Safe while streaming. */
+/**
+ * Snapshot USB/RF health from live metrics (lifetime / cumulative from stream
+ * start). Safe while streaming.
+ *
+ * Pre-reader ring overflow and other early drops remain in these counters for
+ * the whole stream. For soak / app window measurement use
+ * esp_rtl_sdr_health_from_window() on two get_metrics() snapshots instead.
+ */
 esp_err_t esp_rtl_sdr_get_health(esp_rtl_sdr_handle_t handle,
                                  esp_rtl_sdr_health_info_t *out_health);
+
+/**
+ * Windowed metrics from two cumulative get_metrics() snapshots.
+ * Pure helper (no handle / mutex). CU8: effective_sps = delta_bytes * 500 / window_ms.
+ * Counter underflows clamp to 0.
+ */
+typedef struct {
+    size_t struct_size;
+    uint64_t delta_bytes;
+    uint32_t delta_short_transfers;
+    uint32_t delta_overruns;
+    uint32_t delta_consumer_drops;
+    uint32_t window_ms;
+    uint32_t programmed_sps;
+    uint32_t effective_sps; /**< scoped SPS for the window only */
+    float efficiency;       /**< effective_sps / programmed_sps; 0 if unknown */
+} esp_rtl_sdr_metrics_window_t;
+
+/**
+ * Fill delta bytes/overruns/consumer_drops/short_transfers plus scoped SPS and
+ * efficiency for [before, after] over window_ms at programmed_sps.
+ * out is not modified on failure.
+ *
+ * @return ESP_OK, or ESP_ERR_INVALID_ARG if a pointer is NULL / window_ms == 0 /
+ *         programmed_sps == 0
+ */
+esp_err_t esp_rtl_sdr_metrics_delta(const esp_rtl_sdr_metrics_t *before,
+                                    const esp_rtl_sdr_metrics_t *after,
+                                    uint32_t window_ms,
+                                    uint32_t programmed_sps,
+                                    esp_rtl_sdr_metrics_window_t *out);
+
+/**
+ * Windowed USB health from two get_metrics() snapshots.
+ * get_health() stays lifetime/cumulative; this is the honest soak/app tool.
+ *
+ * Fills out_health with window deltas in overruns/consumer_drops, scoped
+ * effective_sps/efficiency, and usb/overall in {OK, USB_STARVING, APP_TOO_SLOW,
+ * UNKNOWN}. RF is left UNKNOWN (sample swing is not windowed by these counters).
+ * Priority matches soak scoring: efficiency < 90% -> USB_STARVING; else
+ * delta consumer_drops > 0 -> APP_TOO_SLOW; else OK. Delta overruns are reported
+ * in overruns but do not alone change the enum (callers may still fail a soak).
+ * out_health is not modified on failure.
+ *
+ * @return ESP_OK, or ESP_ERR_INVALID_ARG if a pointer is NULL / window_ms == 0 /
+ *         programmed_sps == 0
+ */
+esp_err_t esp_rtl_sdr_health_from_window(const esp_rtl_sdr_metrics_t *before,
+                                         const esp_rtl_sdr_metrics_t *after,
+                                         uint32_t window_ms,
+                                         uint32_t programmed_sps,
+                                         esp_rtl_sdr_health_info_t *out_health);
 
 void esp_rtl_sdr_passport_opts_default(esp_rtl_sdr_passport_opts_t *opts);
 

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "esp_rtl_sdr",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "description": "Clean-room ESP USB Host client for RTL2832U-class SDR (Blog V4 profile first)",
   "keywords": "sdr, rtl-sdr, rtl2832u, usb, esp32-p4, esp_rtl_sdr",
   "license": "AGPL-3.0-only",

--- a/src/esp_rtl_sdr_policy.cpp
+++ b/src/esp_rtl_sdr_policy.cpp
@@ -6,6 +6,7 @@
 #include "esp_rtl_sdr.h"
 
 #include <cstddef>
+#include <cstdio>
 #include <cstring>
 
 /* -------------------------------------------------------------------------- */
@@ -367,4 +368,98 @@ void esp_rtl_sdr_passport_opts_default(esp_rtl_sdr_passport_opts_t *opts)
     opts->dwell_ms = ESP_RTL_SDR_PASSPORT_DEFAULT_DWELL_MS;
     opts->min_efficiency_pct = 95;
     opts->recommended_only = true;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Windowed metrics / health (pure; no handle state)                          */
+/* -------------------------------------------------------------------------- */
+
+static uint32_t u32_saturating_sub(uint32_t after, uint32_t before)
+{
+    return (after >= before) ? (after - before) : 0u;
+}
+
+static uint64_t u64_saturating_sub(uint64_t after, uint64_t before)
+{
+    return (after >= before) ? (after - before) : 0ull;
+}
+
+esp_err_t esp_rtl_sdr_metrics_delta(const esp_rtl_sdr_metrics_t *before,
+                                    const esp_rtl_sdr_metrics_t *after,
+                                    uint32_t window_ms,
+                                    uint32_t programmed_sps,
+                                    esp_rtl_sdr_metrics_window_t *out)
+{
+    if (before == nullptr || after == nullptr || out == nullptr || window_ms == 0 ||
+        programmed_sps == 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    esp_rtl_sdr_metrics_window_t w{};
+    w.struct_size = sizeof(w);
+    w.delta_bytes = u64_saturating_sub(after->bytes_total, before->bytes_total);
+    w.delta_short_transfers =
+        u32_saturating_sub(after->short_transfers, before->short_transfers);
+    w.delta_overruns = u32_saturating_sub(after->overruns, before->overruns);
+    w.delta_consumer_drops =
+        u32_saturating_sub(after->consumer_drops, before->consumer_drops);
+    w.window_ms = window_ms;
+    w.programmed_sps = programmed_sps;
+    /* CU8: samples = bytes/2; sps = bytes * 500 / window_ms (same as get_metrics). */
+    w.effective_sps = static_cast<uint32_t>((w.delta_bytes * 500ull) / window_ms);
+    w.efficiency = static_cast<float>(w.effective_sps) /
+                   static_cast<float>(programmed_sps);
+    *out = w;
+    return ESP_OK;
+}
+
+esp_err_t esp_rtl_sdr_health_from_window(const esp_rtl_sdr_metrics_t *before,
+                                         const esp_rtl_sdr_metrics_t *after,
+                                         uint32_t window_ms,
+                                         uint32_t programmed_sps,
+                                         esp_rtl_sdr_health_info_t *out_health)
+{
+    if (out_health == nullptr) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    esp_rtl_sdr_metrics_window_t w{};
+    const esp_err_t err =
+        esp_rtl_sdr_metrics_delta(before, after, window_ms, programmed_sps, &w);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    esp_rtl_sdr_health_info_t h{};
+    h.struct_size = sizeof(h);
+    h.usb = ESP_RTL_SDR_HEALTH_OK;
+    h.rf = ESP_RTL_SDR_HEALTH_UNKNOWN;
+    h.overall = ESP_RTL_SDR_HEALTH_OK;
+    h.efficiency = w.efficiency;
+    h.effective_sps = w.effective_sps;
+    h.programmed_sps = programmed_sps;
+    h.overruns = w.delta_overruns;
+    h.consumer_drops = w.delta_consumer_drops;
+    if (after != nullptr) {
+        h.sample_min = after->sample_min;
+        h.sample_max = after->sample_max;
+    }
+    std::snprintf(h.advice, sizeof(h.advice), "ok");
+
+    /* Integer percent matches soak scoring (90% bar; 89% is USB_STARVING). */
+    const int eff_pct =
+        static_cast<int>((static_cast<uint64_t>(w.effective_sps) * 100ull) /
+                         static_cast<uint64_t>(programmed_sps));
+    if (eff_pct < 90) {
+        h.usb = ESP_RTL_SDR_HEALTH_USB_STARVING;
+        h.overall = ESP_RTL_SDR_HEALTH_USB_STARVING;
+        std::snprintf(h.advice, sizeof(h.advice), "USB_STARVING");
+    } else if (w.delta_consumer_drops > 0) {
+        h.usb = ESP_RTL_SDR_HEALTH_APP_TOO_SLOW;
+        h.overall = ESP_RTL_SDR_HEALTH_APP_TOO_SLOW;
+        std::snprintf(h.advice, sizeof(h.advice), "APP_TOO_SLOW");
+    }
+
+    *out_health = h;
+    return ESP_OK;
 }

--- a/tests/host/test_policy.cpp
+++ b/tests/host/test_policy.cpp
@@ -527,7 +527,7 @@ static void test_error_base_unique(void)
     EXPECT_EQ_I(ESP_RTL_SDR_ERR_UNSUPPORTED_DEVICE, ESP_RTL_SDR_ERR_NOT_V4);
 }
 
-static void test_smoke_soak_scope(void)
+static void test_metrics_window_health(void)
 {
     const uint32_t window_ms = 8000;
     const uint32_t sps = 960000;
@@ -535,6 +535,8 @@ static void test_smoke_soak_scope(void)
 
     esp_rtl_sdr_metrics_t before;
     esp_rtl_sdr_metrics_t after;
+    esp_rtl_sdr_metrics_window_t win;
+    esp_rtl_sdr_health_info_t health;
     smoke_soak_scope_t scope;
 
     /* v0.7.11 6x16k artifact: 507904 pre-soak drops must not fail a clean drain. */
@@ -545,11 +547,23 @@ static void test_smoke_soak_scope(void)
     after.consumer_drops = 507904;
     after.overruns = 0;
     after.bytes_total = before.bytes_total + eight_sec_cu8;
+
+    EXPECT_EQ_I(esp_rtl_sdr_metrics_delta(&before, &after, window_ms, sps, &win), ESP_OK);
+    EXPECT_EQ_U(win.delta_consumer_drops, 0u);
+    EXPECT_EQ_U(win.delta_overruns, 0u);
+    EXPECT_TRUE(win.delta_bytes == eight_sec_cu8);
+    EXPECT_EQ_U(win.effective_sps, sps);
+    EXPECT_EQ_I(esp_rtl_sdr_health_from_window(&before, &after, window_ms, sps, &health),
+                ESP_OK);
+    EXPECT_EQ_I((int)health.overall, (int)ESP_RTL_SDR_HEALTH_OK);
+    EXPECT_EQ_I((int)health.usb, (int)ESP_RTL_SDR_HEALTH_OK);
+    EXPECT_EQ_I((int)health.rf, (int)ESP_RTL_SDR_HEALTH_UNKNOWN);
+    EXPECT_EQ_U(health.consumer_drops, 0u);
+    EXPECT_STREQ(health.advice, "ok");
+
     std::memset(&scope, 0, sizeof(scope));
     smoke_soak_scope_from_metrics(&before, &after, window_ms, sps, &scope);
     EXPECT_EQ_U(scope.delta_consumer_drops, 0u);
-    EXPECT_EQ_U(scope.delta_overruns, 0u);
-    EXPECT_TRUE(scope.delta_bytes == eight_sec_cu8);
     EXPECT_EQ_U(scope.scoped_sps, sps);
     EXPECT_EQ_I(scope.eff_pct, 100);
     EXPECT_STREQ(scope.advice, "ok");
@@ -558,20 +572,38 @@ static void test_smoke_soak_scope(void)
     /* v0.7.11 3x32k artifact: 593920 cumulative drops, zero delta. */
     before.consumer_drops = 593920;
     after.consumer_drops = 593920;
+    EXPECT_EQ_I(esp_rtl_sdr_metrics_delta(&before, &after, window_ms, sps, &win), ESP_OK);
+    EXPECT_EQ_U(win.delta_consumer_drops, 0u);
+    EXPECT_EQ_I(esp_rtl_sdr_health_from_window(&before, &after, window_ms, sps, &health),
+                ESP_OK);
+    EXPECT_EQ_I((int)health.overall, (int)ESP_RTL_SDR_HEALTH_OK);
     smoke_soak_scope_from_metrics(&before, &after, window_ms, sps, &scope);
     EXPECT_EQ_U(scope.delta_consumer_drops, 0u);
     EXPECT_TRUE(scope.pass);
 
     /* Genuine scoped drops stay visible. */
     after.consumer_drops = 593920 + 16384;
+    EXPECT_EQ_I(esp_rtl_sdr_metrics_delta(&before, &after, window_ms, sps, &win), ESP_OK);
+    EXPECT_EQ_U(win.delta_consumer_drops, 16384u);
+    EXPECT_EQ_I(esp_rtl_sdr_health_from_window(&before, &after, window_ms, sps, &health),
+                ESP_OK);
+    EXPECT_EQ_I((int)health.overall, (int)ESP_RTL_SDR_HEALTH_APP_TOO_SLOW);
+    EXPECT_EQ_I((int)health.usb, (int)ESP_RTL_SDR_HEALTH_APP_TOO_SLOW);
+    EXPECT_STREQ(health.advice, "APP_TOO_SLOW");
     smoke_soak_scope_from_metrics(&before, &after, window_ms, sps, &scope);
     EXPECT_EQ_U(scope.delta_consumer_drops, 16384u);
     EXPECT_STREQ(scope.advice, "APP_TOO_SLOW");
     EXPECT_TRUE(!scope.pass);
 
-    /* Scoped overruns fail even when drops are unchanged. */
+    /* Scoped overruns: public health stays OK; soak adapter still fails pass. */
     after.consumer_drops = before.consumer_drops;
     after.overruns = 3;
+    EXPECT_EQ_I(esp_rtl_sdr_metrics_delta(&before, &after, window_ms, sps, &win), ESP_OK);
+    EXPECT_EQ_U(win.delta_overruns, 3u);
+    EXPECT_EQ_I(esp_rtl_sdr_health_from_window(&before, &after, window_ms, sps, &health),
+                ESP_OK);
+    EXPECT_EQ_U(health.overruns, 3u);
+    EXPECT_EQ_I((int)health.overall, (int)ESP_RTL_SDR_HEALTH_OK);
     smoke_soak_scope_from_metrics(&before, &after, window_ms, sps, &scope);
     EXPECT_EQ_U(scope.delta_overruns, 3u);
     EXPECT_TRUE(!scope.pass);
@@ -579,6 +611,9 @@ static void test_smoke_soak_scope(void)
     /* 90% of programmed CU8 in 8 s meets the efficiency bar. */
     after.overruns = 0;
     after.bytes_total = before.bytes_total + (eight_sec_cu8 * 90ull) / 100ull;
+    EXPECT_EQ_I(esp_rtl_sdr_health_from_window(&before, &after, window_ms, sps, &health),
+                ESP_OK);
+    EXPECT_EQ_I((int)health.overall, (int)ESP_RTL_SDR_HEALTH_OK);
     smoke_soak_scope_from_metrics(&before, &after, window_ms, sps, &scope);
     EXPECT_EQ_I(scope.eff_pct, 90);
     EXPECT_STREQ(scope.advice, "ok");
@@ -586,6 +621,11 @@ static void test_smoke_soak_scope(void)
 
     /* 89% of programmed CU8 in 8 s is USB_STARVING. */
     after.bytes_total = before.bytes_total + (eight_sec_cu8 * 89ull) / 100ull;
+    EXPECT_EQ_I(esp_rtl_sdr_metrics_delta(&before, &after, window_ms, sps, &win), ESP_OK);
+    EXPECT_EQ_I(esp_rtl_sdr_health_from_window(&before, &after, window_ms, sps, &health),
+                ESP_OK);
+    EXPECT_EQ_I((int)health.overall, (int)ESP_RTL_SDR_HEALTH_USB_STARVING);
+    EXPECT_STREQ(health.advice, "USB_STARVING");
     smoke_soak_scope_from_metrics(&before, &after, window_ms, sps, &scope);
     EXPECT_EQ_I(scope.eff_pct, 89);
     EXPECT_STREQ(scope.advice, "USB_STARVING");
@@ -597,6 +637,10 @@ static void test_smoke_soak_scope(void)
     EXPECT_TRUE(scope.delta_bytes == 0);
     EXPECT_TRUE(!scope.pass);
 
+    EXPECT_EQ_I(esp_rtl_sdr_metrics_delta(nullptr, &after, window_ms, sps, &win),
+                ESP_ERR_INVALID_ARG);
+    EXPECT_EQ_I(esp_rtl_sdr_health_from_window(nullptr, &after, window_ms, sps, &health),
+                ESP_ERR_INVALID_ARG);
     smoke_soak_scope_from_metrics(nullptr, &after, window_ms, sps, &scope);
     EXPECT_STREQ(scope.advice, "invalid");
     EXPECT_TRUE(!scope.pass);
@@ -658,7 +702,7 @@ int main(void)
     test_passport_opts();
     test_usb_identity_constants();
     test_error_base_unique();
-    test_smoke_soak_scope();
+    test_metrics_window_health();
     test_smoke_urb_image_isolation();
     std::printf("RESULT passed=%d failed=%d\n", g_passed, g_failed);
     return g_failed == 0 ? 0 : 1;


### PR DESCRIPTION
## Summary
- Public pure helpers `esp_rtl_sdr_metrics_delta` and `esp_rtl_sdr_health_from_window` score a soak/app window from two `get_metrics()` snapshots (delta bytes/overruns/drops/shorts, scoped SPS, efficiency, USB health enums).
- `get_health()` remains lifetime/cumulative from stream start; docs call out that early pull-ring overflow must not be treated as soak drops.
- `p4_serial_smoke` `smoke_soak_scope.h` is now a thin adapter over the public helpers (single scorer).
- Host tests cover the v0.7.11 507904/593920 artifacts against the public API; version bumped to **0.7.13**.

## Test plan
- [x] `tests\scripts\run_host_tests.ps1` → `RESULT passed=291 failed=0`
- [ ] No COM17 flash / no Tab5 re-soak required for this slice
- [ ] Do not merge/tag unless requested


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added windowed metrics and health analysis using before-and-after snapshots.
  - Reports window-scoped bytes, overruns, dropped data, short transfers, effective sample rate, efficiency, and USB health status.
  - Preserves cumulative, stream-lifetime health reporting separately from windowed analysis.

- **Documentation**
  - Updated API documentation and project references for version 0.7.13.
  - Clarified lifetime versus windowed health metrics and usage.

- **Tests**
  - Expanded smoke-test coverage for windowed metrics and health classifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->