### PR TITLE
fix(0.7.14): drain live URBs before free_bulk_pool on stop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # P4 USB host path: IDF 5.3+; pin known release tags for reproducibility
-        idf_ver: ["v5.3.2", "v5.4.1"]
+        # Match OrcSDR Tab5 floor (IDF 5.5.x); build the same pin OrcSDR locks
+        idf_ver: ["v5.5.4"]
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+## 0.7.14 (2026-09-07)
+
+### Fixed
+
+- **stop drains live URBs before free_bulk_pool (Tab5 HCD race):**
+  `stop_stream_internal()` (used by `esp_rtl_sdr_stop`, e.g. POCSAG band-switch
+  stop→start) previously halt/flush/clear'd, then took a fixed `bulk_num` ×
+  timed semaphore, then unconditionally zeroed `live_urbs` and freed the bulk
+  transfer pool. That could free a `usb_transfer_t` while IDF DWC HCD still had
+  a bulk descriptor in flight → `_buffer_parse_bulk` assert
+  (`desc_status != SUCCESS`) on Tab5. Stop now matches `bulk_pause_and_drain`:
+  shared `drain_live_urbs()` polls `live_urbs`→0, halt/flush/clear only if still
+  live, polls again, and **does not** call `free_bulk_pool` until `live_urbs==0`
+  (on drain timeout: skip free, keep `pause_resubmit`, return
+  `ESP_RTL_SDR_ERR_TIMEOUT`, state FAULT). `free_bulk_pool` also refuses while
+  `live_urbs>0`. Uninstall may clear a stuck counter only after host teardown.
+
 ## 0.7.13 (2026-09-05)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## 0.7.14 (2026-09-07)
 
+### Changed
+
+- **ESP-IDF floor raised to 5.5.0** (CI builds `v5.5.4`, same floor as OrcSDR Tab5).
+
 ### Fixed
 
 - **stop drains live URBs before free_bulk_pool (Tab5 HCD race):**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@
   (on drain timeout: skip free, keep `pause_resubmit`, return
   `ESP_RTL_SDR_ERR_TIMEOUT`, state FAULT). `free_bulk_pool` also refuses while
   `live_urbs>0`. Uninstall may clear a stuck counter only after host teardown.
+- **reset refuses while live URBs outstanding:** `esp_rtl_sdr_reset()` returns
+  `ESP_RTL_SDR_ERR_BUSY` and keeps FAULT when `live_urbs>0` (after timed-out
+  stop) so start cannot orphan the old transfer pool while callbacks may still
+  fire; caller retries stop until drain, then reset.
+- **uninstall does not free pool if host uninstall fails:** check
+  `usb_host_uninstall()` return; only clear stuck `live_urbs` / `free_bulk_pool`
+  after success; on failure leave pool, clear `destroying`, return ERR_USB.
 
 ## 0.7.13 (2026-09-05)
 

--- a/PROJECT_TRUTH.md
+++ b/PROJECT_TRUTH.md
@@ -7,7 +7,7 @@ Same discipline as [TheOrc PROJECT_TRUTH](https://github.com/hardcoreerik/TheOrc
 claims need evidence labels; oversell is a bug; retract rather than spin.
 
 Snapshot date: **2026-09-05**  
-Version: **0.7.13** (public windowed metrics/health; smoke SOAK wraps it; USB soak still operator work - not production-ready)
+Version: **0.7.14** (stop drains live URBs before free_bulk_pool; public windowed metrics/health; USB soak still operator work - not production-ready)
 Local repo: `F:\Ai\ESP_RTL_SDR\`  
 Remote: **https://github.com/hardcoreerik/esp-rtl-sdr**  
 Open-source honesty: [docs/AI_DEVELOPMENT_DISCLOSURE.md](docs/AI_DEVELOPMENT_DISCLOSURE.md) ·
@@ -123,6 +123,7 @@ Product vision: **`docs/VISION.md`**. Silicon / DS map: **`docs/SILICON.md`**.
 | **0.7.11** | Smoke soak_drain 16 KiB buffer off the 4 KiB task stack (#11) |
 | **0.7.12** | Smoke SOAK evidence is scoped to the drain window (not pre-soak ring overflow) |
 | **0.7.13** | Public metrics_delta / health_from_window from metric snapshots (honest soak/app window) |
+| **0.7.14** | stop_stream_internal drains live URBs (shared with pause) before free_bulk_pool; avoids Tab5 HCD assert on band-switch stop→start |
 
 ---
 

--- a/PROJECT_TRUTH.md
+++ b/PROJECT_TRUTH.md
@@ -6,7 +6,7 @@ wins for *what is true right now*.
 Same discipline as [TheOrc PROJECT_TRUTH](https://github.com/hardcoreerik/TheOrc):
 claims need evidence labels; oversell is a bug; retract rather than spin.
 
-Snapshot date: **2026-09-05**  
+Snapshot date: **2026-09-07**  
 Version: **0.7.14** (stop drains live URBs before free_bulk_pool; public windowed metrics/health; USB soak still operator work - not production-ready)
 Local repo: `F:\Ai\ESP_RTL_SDR\`  
 Remote: **https://github.com/hardcoreerik/esp-rtl-sdr**  

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Make an RTL-SDR Blog V4 a first-class peripheral on ESP32-P4** — continuous I/Q over USB Host, with a real embedded driver API.
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
-![Status](https://img.shields.io/badge/version-0.7.13-green)
+![Status](https://img.shields.io/badge/version-0.7.14-green)
 [![GitHub](https://img.shields.io/badge/github-esp--rtl--sdr-black)](https://github.com/hardcoreerik/esp-rtl-sdr)
 ![Target](https://img.shields.io/badge/ESP32--P4-HS_USB-green)
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ We are **not** chasing full librtlsdr feature parity (tuner IF filter still open
 |---|---|
 | **MCU** | **ESP32-P4** with High-Speed USB Host (e.g. M5Stack Tab5, Waveshare P4 kit) |
 | **Dongle** | **RTL-SDR Blog V4** — USB **`0bda:2838`**, mfg/product strings `RTLSDRBlog` / `Blog V4` |
-| **Tooling** | ESP-IDF **≥ 5.3** with `esp32p4` support |
+| **Tooling** | ESP-IDF **≥ 5.5** with `esp32p4` support (OrcSDR Tab5 uses 5.5.4) |
 | **Antenna** | For RF; compile/smoke works without RF |
 
 **Not claimed yet:** ESP32-S2/S3 Full-Speed hosts, random eBay RTL sticks, production warranty.  

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -61,7 +61,7 @@ Review-driven (pause Phase 3 hardware for one release):
 - [x] Kconfig defaults wired
 - [x] Pull-ring memcpy optimization
 - [x] Component `targets: esp32p4`
-- [x] ESP-IDF P4 compile CI (`idf-p4-build` on 5.3.2 + 5.4.1)
+- [x] ESP-IDF P4 compile CI (`idf-p4-build` on 5.5.4)
 - [x] True async retune from callback (queue + delivery apply + EVT_RETUNED)
 - [x] Delivery CALLBACK/READ/BOTH + lazy pull ring (**0.7.4**)
 - [ ] Lab soak evidence from this tree (procedure ready: `docs/SOAK.md`)

--- a/docs/SCOPE.md
+++ b/docs/SCOPE.md
@@ -12,7 +12,7 @@ This project **fails closed** on unsupported hardware. Narrow support is a
 | **MCU** | ESP32-**P4** High-Speed USB Host | e.g. M5Stack Tab5, Waveshare P4 kits |
 | **Dongle** | RTL-SDR **Blog V4** | USB `0bda:2838`, mfg/product `RTLSDRBlog` / `Blog V4` |
 | **IQ** | Continuous CU8 multi-URB | CAP_STREAM |
-| **Tooling** | ESP-IDF ≥ 5.3, `esp32p4` | CI builds smoke on 5.3.2 + 5.4.1 |
+| **Tooling** | ESP-IDF ≥ 5.5, `esp32p4` | CI builds smoke on 5.5.4 |
 
 Evidence labels: [`../PROJECT_TRUTH.md`](../PROJECT_TRUTH.md).
 

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -75,7 +75,7 @@ Workflow: `.github/workflows/ci.yml`
 
 1. **host-policy** — Ubuntu + Windows matrix; `-Werror` on Linux; `ctest` + direct run  
 2. **truth-hygiene** — `tests/scripts/check_truth_hygiene.sh` (versions, required docs, CAP_GAIN/BIAS only with MEASURED marker + tables)  
-3. **idf-p4-build** — `examples/p4_serial_smoke` with `idf.py set-target esp32p4` + `build` on ESP-IDF **v5.3.2** and **v5.4.1** (compile only; no flash/RF)  
+3. **idf-p4-build** — `examples/p4_serial_smoke` with `idf.py set-target esp32p4` + `build` on ESP-IDF **v5.5.4** (compile only; no flash/RF; matches OrcSDR Tab5 floor)  
 4. **ci-ok** — aggregate gate  
 
 | Green means | Does **not** mean |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -11,7 +11,7 @@ Truth of claims: [`../PROJECT_TRUTH.md`](../PROJECT_TRUTH.md).
 |---|---|
 | `esp_rtl_sdr.h` not found | Component on `EXTRA_COMPONENT_DIRS` or under `components/esp_rtl_sdr`; `REQUIRES esp_rtl_sdr` |
 | Wrong target | `idf.py set-target esp32p4` — P4 only claimed |
-| IDF too old | Need **≥ 5.3** with esp32p4 |
+| IDF too old | Need **≥ 5.5** with esp32p4 |
 | Host tests fail | `tests/scripts/run_host_tests.ps1` (or `.sh`); no IDF required |
 
 ---

--- a/examples/p4_serial_smoke/CMakeLists.txt
+++ b/examples/p4_serial_smoke/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 
-# Pin app version so idf.py project_description is 0.7.13, not git-describe
+# Pin app version so idf.py project_description is 0.7.14, not git-describe
 # of an older tag.
-set(PROJECT_VER "0.7.13")
+set(PROJECT_VER "0.7.14")
 
 # IDF 5.5.4 defaults SDKCONFIG to ${CMAKE_SOURCE_DIR}/sdkconfig. -B only
 # changes the binary dir, so two URB images would share one config. Keep

--- a/examples/p4_serial_smoke/main/main.cpp
+++ b/examples/p4_serial_smoke/main/main.cpp
@@ -1,5 +1,5 @@
 /*
- * ESP-IDF Tab5 / P4 drop-in smoke for esp_rtl_sdr public API (v0.7.13).
+ * ESP-IDF Tab5 / P4 drop-in smoke for esp_rtl_sdr public API (v0.7.14).
  *
  * One USB host install per boot. URB layout is a Kconfig choice so A/B
  * (6x16 KiB vs 3x32 KiB) is two firmware images, not two installs.
@@ -156,7 +156,7 @@ static void check_pure_helpers(void)
     smoke_row("rate_4M_reject", !esp_rtl_sdr_is_rate_supported(4000000));
 
     const char *ver = esp_rtl_sdr_get_version_string();
-    smoke_row("version_0_7_13", ver != NULL && strcmp(ver, "0.7.13") == 0);
+    smoke_row("version_0_7_14", ver != NULL && strcmp(ver, "0.7.14") == 0);
 
     const uint32_t caps = esp_rtl_sdr_get_capabilities();
     smoke_row("cap_gain", (caps & ESP_RTL_SDR_CAP_GAIN) != 0);

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,5 +1,5 @@
 ## esp_rtl_sdr — ESP Component Registry metadata
-version: "0.7.13"
+version: "0.7.14"
 description: >
   Clean-room ESP-IDF USB Host client for RTL2832U-class SDR dongles.
   Blog V4 (R828D) profile first; profile-based expansion for other tuners.

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -18,4 +18,4 @@ tags:
   - esp32-p4
 dependencies:
   idf:
-    version: ">=5.3.0"
+    version: ">=5.5.0"

--- a/include/esp_rtl_sdr.h
+++ b/include/esp_rtl_sdr.h
@@ -87,7 +87,7 @@ extern "C" {
 /** Semantic version of this public header / binary API. */
 #define ESP_RTL_SDR_VERSION_MAJOR 0
 #define ESP_RTL_SDR_VERSION_MINOR 7
-#define ESP_RTL_SDR_VERSION_PATCH 13
+#define ESP_RTL_SDR_VERSION_PATCH 14
 
 #define ESP_RTL_SDR_VERSION_NUMBER                                      \
     ((ESP_RTL_SDR_VERSION_MAJOR * 10000) +                              \
@@ -696,6 +696,10 @@ esp_err_t esp_rtl_sdr_retune_hz(esp_rtl_sdr_handle_t handle, uint32_t frequency_
 /**
  * Stop stream and run cleanup. Idempotent if already idle.
  * Blocks up to timeout_ms for USB cleanup (0 = DEFAULT_STOP_TIMEOUT_MS).
+ * Drains live bulk URBs (same order as retune pause) before freeing the
+ * transfer pool; returns ESP_RTL_SDR_ERR_TIMEOUT and leaves FAULT if drain
+ * cannot reach live_urbs==0 (pool is not freed while transfers may be in
+ * flight — avoids Tab5 HCD assert on stop→start).
  * Emits EVT_STOPPED once when leaving STREAMING/STOPPING/FAULT-with-stream.
  */
 esp_err_t esp_rtl_sdr_stop(esp_rtl_sdr_handle_t handle, uint32_t timeout_ms);

--- a/include/esp_rtl_sdr.h
+++ b/include/esp_rtl_sdr.h
@@ -699,14 +699,19 @@ esp_err_t esp_rtl_sdr_retune_hz(esp_rtl_sdr_handle_t handle, uint32_t frequency_
  * Drains live bulk URBs (same order as retune pause) before freeing the
  * transfer pool; returns ESP_RTL_SDR_ERR_TIMEOUT and leaves FAULT if drain
  * cannot reach live_urbs==0 (pool is not freed while transfers may be in
- * flight — avoids Tab5 HCD assert on stop→start).
+ * flight - avoids Tab5 HCD assert on stop->start).
+ * On TIMEOUT: interface may remain claimed, bulk pool may be kept, and full
+ * idle cleanup is not performed (retry stop until drain succeeds).
  * Emits EVT_STOPPED once when leaving STREAMING/STOPPING/FAULT-with-stream.
  */
 esp_err_t esp_rtl_sdr_stop(esp_rtl_sdr_handle_t handle, uint32_t timeout_ms);
 
 /**
  * Clear FAULT back to IDLE if hardware allows (no open stream).
- * If still streaming, returns ERR_BUSY. Clears metrics counters on success.
+ * If still streaming / starting / stopping, returns ERR_BUSY.
+ * Refuses while live URBs are outstanding (ERR_BUSY) and keeps FAULT; does
+ * not clear state/metrics. Caller should retry esp_rtl_sdr_stop() until drain
+ * succeeds, then reset. Clears metrics counters on success.
  */
 esp_err_t esp_rtl_sdr_reset(esp_rtl_sdr_handle_t handle);
 

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "esp_rtl_sdr",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "description": "Clean-room ESP USB Host client for RTL2832U-class SDR (Blog V4 profile first)",
   "keywords": "sdr, rtl-sdr, rtl2832u, usb, esp32-p4, esp_rtl_sdr",
   "license": "AGPL-3.0-only",

--- a/src/esp_rtl_sdr.cpp
+++ b/src/esp_rtl_sdr.cpp
@@ -2273,7 +2273,6 @@ esp_err_t esp_rtl_sdr_reset(esp_rtl_sdr_handle_t handle)
     set_error_unlocked(handle, ESP_OK);
     return ESP_OK;
 }
-}
 
 esp_err_t esp_rtl_sdr_release_iq_block(esp_rtl_sdr_handle_t handle,
                                           const esp_rtl_sdr_iq_block_t *block)

--- a/src/esp_rtl_sdr.cpp
+++ b/src/esp_rtl_sdr.cpp
@@ -118,7 +118,10 @@ struct esp_rtl_sdr_handle {
     uint32_t bulk_num = 0;
     uint32_t bulk_len = 0;
     volatile bool streaming = false;
-    /** Live bulk URBs currently submitted (not yet completed without resubmit). */
+    /** Live bulk URBs currently submitted (not yet completed without resubmit).
+     * Free-pool gate: free_bulk_pool / stop / reset refuse while >0.
+     * Relies on aligned 32-bit loads plus USB callback serialization
+     * (bulk_cb vs stop/reset under handle lock / streaming=false). */
     volatile uint32_t live_urbs = 0;
     /** When true, bulk_cb must not resubmit (stop or retune drain). */
     volatile bool pause_resubmit = false;
@@ -771,8 +774,9 @@ static bool drain_live_urbs(esp_rtl_sdr_handle *h, uint32_t poll_ms, uint32_t fl
         return true;
     }
     if (poll_ms > 0 && h->live_urbs > 0) {
-        const TickType_t deadline = xTaskGetTickCount() + pdMS_TO_TICKS(poll_ms);
-        while (h->live_urbs > 0 && xTaskGetTickCount() < deadline) {
+        const TickType_t start = xTaskGetTickCount();
+        const TickType_t wait = pdMS_TO_TICKS(poll_ms);
+        while (h->live_urbs > 0 && (xTaskGetTickCount() - start) < wait) {
             vTaskDelay(pdMS_TO_TICKS(2));
         }
     }
@@ -781,8 +785,9 @@ static bool drain_live_urbs(esp_rtl_sdr_handle *h, uint32_t poll_ms, uint32_t fl
         usb_host_endpoint_flush(h->dev, ESP_RTL_SDR_BULK_EP_IN);
         usb_host_endpoint_clear(h->dev, ESP_RTL_SDR_BULK_EP_IN);
         if (flush_poll_ms > 0) {
-            const TickType_t d2 = xTaskGetTickCount() + pdMS_TO_TICKS(flush_poll_ms);
-            while (h->live_urbs > 0 && xTaskGetTickCount() < d2) {
+            const TickType_t start2 = xTaskGetTickCount();
+            const TickType_t wait2 = pdMS_TO_TICKS(flush_poll_ms);
+            while (h->live_urbs > 0 && (xTaskGetTickCount() - start2) < wait2) {
                 vTaskDelay(pdMS_TO_TICKS(2));
             }
         }
@@ -1763,11 +1768,23 @@ esp_err_t esp_rtl_sdr_uninstall(esp_rtl_sdr_handle_t handle)
         handle->client_registered = false;
     }
     if (handle->owns_host && handle->host_installed) {
-        usb_host_uninstall();
+        const esp_err_t uerr = usb_host_uninstall();
+        if (uerr != ESP_OK) {
+            /* Fail-closed: do not clear live_urbs or free the pool while the
+             * host may still own transfers. Leave handle intact for retry. */
+            ESP_LOGE(TAG, "usb_host_uninstall failed (%s); keep pool/live_urbs",
+                     esp_err_to_name(uerr));
+            {
+                HandleLock lk(handle, kUninstallLockTicks);
+                (void)lk.ok();
+                handle->destroying = false; /* allow uninstall retry */
+            }
+            return ESP_RTL_SDR_ERR_USB;
+        }
         handle->host_installed = false;
     }
 
-    /* Host/HCD torn down — safe to clear a stuck live_urbs so pool can free. */
+    /* Host/HCD torn down (or never owned) - safe to clear stuck live_urbs. */
     if (handle->live_urbs > 0) {
         ESP_LOGW(TAG, "uninstall: clearing stuck live_urbs=%u after host teardown",
                  static_cast<unsigned>(handle->live_urbs));
@@ -2240,10 +2257,22 @@ esp_err_t esp_rtl_sdr_reset(esp_rtl_sdr_handle_t handle)
         set_error_unlocked(handle, ESP_RTL_SDR_ERR_BUSY);
         return ESP_RTL_SDR_ERR_BUSY;
     }
+    /* After timed-out stop (FAULT, live_urbs>0, pool kept): refuse reset so
+     * start cannot alloc_bulk_pool -> free_bulk_pool orphan the old array
+     * while callbacks may still fire. Caller should retry stop until drain. */
+    if (handle->live_urbs > 0) {
+        set_error_unlocked(handle, ESP_RTL_SDR_ERR_BUSY);
+        return ESP_RTL_SDR_ERR_BUSY;
+    }
+    /* live_urbs==0 but pool still allocated (e.g. odd FAULT path): free it. */
+    if (handle->bulk != nullptr) {
+        free_bulk_pool(handle);
+    }
     handle->state = ESP_RTL_SDR_STATE_IDLE;
     std::memset(&handle->metrics, 0, sizeof(handle->metrics));
     set_error_unlocked(handle, ESP_OK);
     return ESP_OK;
+}
 }
 
 esp_err_t esp_rtl_sdr_release_iq_block(esp_rtl_sdr_handle_t handle,

--- a/src/esp_rtl_sdr.cpp
+++ b/src/esp_rtl_sdr.cpp
@@ -759,6 +759,37 @@ static void bulk_cb(usb_transfer_t *xfer)
     }
 }
 
+/**
+ * Poll live_urbs after pause_resubmit / streaming=false is set.
+ * If still live after poll_ms, halt/flush/clear the bulk IN endpoint and poll
+ * again for flush_poll_ms. Does not force the counter and does not free the pool.
+ * @return true if live_urbs == 0 when finished.
+ */
+static bool drain_live_urbs(esp_rtl_sdr_handle *h, uint32_t poll_ms, uint32_t flush_poll_ms)
+{
+    if (h == nullptr) {
+        return true;
+    }
+    if (poll_ms > 0 && h->live_urbs > 0) {
+        const TickType_t deadline = xTaskGetTickCount() + pdMS_TO_TICKS(poll_ms);
+        while (h->live_urbs > 0 && xTaskGetTickCount() < deadline) {
+            vTaskDelay(pdMS_TO_TICKS(2));
+        }
+    }
+    if (h->live_urbs > 0 && h->dev != nullptr) {
+        usb_host_endpoint_halt(h->dev, ESP_RTL_SDR_BULK_EP_IN);
+        usb_host_endpoint_flush(h->dev, ESP_RTL_SDR_BULK_EP_IN);
+        usb_host_endpoint_clear(h->dev, ESP_RTL_SDR_BULK_EP_IN);
+        if (flush_poll_ms > 0) {
+            const TickType_t d2 = xTaskGetTickCount() + pdMS_TO_TICKS(flush_poll_ms);
+            while (h->live_urbs > 0 && xTaskGetTickCount() < d2) {
+                vTaskDelay(pdMS_TO_TICKS(2));
+            }
+        }
+    }
+    return h->live_urbs == 0;
+}
+
 /** Pause bulk IN and drain live URBs so EP0 is safe (retune / gain / bias). */
 static void bulk_pause_and_drain(esp_rtl_sdr_handle *h)
 {
@@ -766,18 +797,8 @@ static void bulk_pause_and_drain(esp_rtl_sdr_handle *h)
         return;
     }
     h->pause_resubmit = true;
-    const TickType_t deadline = xTaskGetTickCount() + pdMS_TO_TICKS(800);
-    while (h->live_urbs > 0 && xTaskGetTickCount() < deadline) {
-        vTaskDelay(pdMS_TO_TICKS(2));
-    }
-    if (h->live_urbs > 0 && h->dev != nullptr) {
-        usb_host_endpoint_halt(h->dev, ESP_RTL_SDR_BULK_EP_IN);
-        usb_host_endpoint_flush(h->dev, ESP_RTL_SDR_BULK_EP_IN);
-        usb_host_endpoint_clear(h->dev, ESP_RTL_SDR_BULK_EP_IN);
-        const TickType_t d2 = xTaskGetTickCount() + pdMS_TO_TICKS(300);
-        while (h->live_urbs > 0 && xTaskGetTickCount() < d2) {
-            vTaskDelay(pdMS_TO_TICKS(2));
-        }
+    if (!drain_live_urbs(h, 800, 300)) {
+        /* Pool is kept for resume; force counter so EP0 path can proceed. */
         h->live_urbs = 0;
     }
 }
@@ -1190,6 +1211,16 @@ static void delivery_task_fn(void *arg)
 
 static void free_bulk_pool(esp_rtl_sdr_handle *h)
 {
+    if (h == nullptr) {
+        return;
+    }
+    /* Never free usb_transfer_t while IDF DWC HCD may still own a bulk desc
+     * (Tab5 _buffer_parse_bulk assert: desc_status != SUCCESS). */
+    if (h->live_urbs > 0) {
+        ESP_LOGW(TAG, "free_bulk_pool refused: live_urbs=%u",
+                 static_cast<unsigned>(h->live_urbs));
+        return;
+    }
     if (h->bulk != nullptr) {
         for (uint32_t i = 0; i < h->bulk_num; ++i) {
             if (h->bulk[i] != nullptr) {
@@ -1736,6 +1767,12 @@ esp_err_t esp_rtl_sdr_uninstall(esp_rtl_sdr_handle_t handle)
         handle->host_installed = false;
     }
 
+    /* Host/HCD torn down — safe to clear a stuck live_urbs so pool can free. */
+    if (handle->live_urbs > 0) {
+        ESP_LOGW(TAG, "uninstall: clearing stuck live_urbs=%u after host teardown",
+                 static_cast<unsigned>(handle->live_urbs));
+        handle->live_urbs = 0;
+    }
     free_bulk_pool(handle);
     if (handle->ctrl_xfer) {
         usb_host_transfer_free(handle->ctrl_xfer);
@@ -1863,32 +1900,52 @@ static esp_err_t stop_stream_internal(esp_rtl_sdr_handle *h, uint32_t timeout_ms
     h->pending_rtl_agc = false;
     h->ep0_sideband_busy = false;
 
-    if (h->dev != nullptr && h->bulk_num > 0) {
-        usb_host_endpoint_halt(h->dev, ESP_RTL_SDR_BULK_EP_IN);
-        usb_host_endpoint_flush(h->dev, ESP_RTL_SDR_BULK_EP_IN);
-        usb_host_endpoint_clear(h->dev, ESP_RTL_SDR_BULK_EP_IN);
+    /* Same order as bulk_pause_and_drain (shared drain_live_urbs): poll natural
+     * completions first, halt/flush/clear only if still live, poll again.
+     * stop clears streaming before drain, so call the helper directly (pause
+     * early-returns when !streaming). Never free_bulk_pool while live_urbs>0
+     * — that races Tab5 DWC HCD (_buffer_parse_bulk desc_status assert) on
+     * band-switch stop->start (e.g. POCSAG). */
+    uint32_t poll_ms = 800;
+    uint32_t flush_ms = 300;
+    if (timeout_ms < poll_ms + flush_ms) {
+        flush_ms = timeout_ms / 4;
+        poll_ms = timeout_ms - flush_ms;
+    }
+    const bool drained = drain_live_urbs(h, poll_ms, flush_ms);
+
+    if (drained) {
+        /* Hygiene for next start after live_urbs is verified 0. */
+        if (h->bulk_done_sem != nullptr) {
+            while (xSemaphoreTake(h->bulk_done_sem, 0) == pdTRUE) {
+            }
+        }
+        h->live_urbs = 0;
+        h->pause_resubmit = false;
+    } else {
+        ESP_LOGW(TAG, "stop: drain timeout live_urbs=%u; skip free_bulk_pool",
+                 static_cast<unsigned>(h->live_urbs));
+        /* Keep pause_resubmit so late bulk_cb does not resubmit. */
     }
 
-    /* Drain completion callbacks (bounded). */
-    const uint32_t need = h->bulk_num > 0 ? h->bulk_num : 1;
-    const TickType_t slice = pdMS_TO_TICKS(timeout_ms / need + 20);
-    for (uint32_t i = 0; i < need; ++i) {
-        (void)xSemaphoreTake(h->bulk_done_sem, slice);
-    }
-    h->live_urbs = 0;
-    h->pause_resubmit = false;
-
-    if (h->iface_claimed && h->dev != nullptr) {
+    if (drained && h->iface_claimed && h->dev != nullptr) {
         run_cleanup_best_effort(h);
         usb_host_interface_release(h->client, h->dev, 0);
         h->iface_claimed = false;
     }
 
-    free_bulk_pool(h);
+    if (drained) {
+        free_bulk_pool(h);
+    }
     pull_ring_reset(h);
     h->stream_start_ms = 0;
-    h->state = ESP_RTL_SDR_STATE_IDLE;
-    set_error_unlocked(h, ESP_OK);
+    if (drained) {
+        h->state = ESP_RTL_SDR_STATE_IDLE;
+        set_error_unlocked(h, ESP_OK);
+    } else {
+        h->state = ESP_RTL_SDR_STATE_FAULT;
+        set_error_unlocked(h, ESP_RTL_SDR_ERR_TIMEOUT);
+    }
 
     if (was_streaming && !h->destroying) {
         esp_rtl_sdr_event_cb_t cb = h->cfg.event_cb;
@@ -1897,7 +1954,7 @@ static esp_err_t stop_stream_internal(esp_rtl_sdr_handle *h, uint32_t timeout_ms
             emit_after_unlock(h, ESP_RTL_SDR_EVT_STOPPED, nullptr, cb, ctx);
         }
     }
-    return ESP_OK;
+    return drained ? ESP_OK : ESP_RTL_SDR_ERR_TIMEOUT;
 }
 
 esp_err_t esp_rtl_sdr_start(esp_rtl_sdr_handle_t handle,


### PR DESCRIPTION
## Summary
- Extract shared `drain_live_urbs()` used by `bulk_pause_and_drain` and `stop_stream_internal`.
- Stop now polls `live_urbs`→0, halt/flush/clear only if still live, polls again, and **never** calls `free_bulk_pool` while `live_urbs>0` (Tab5 DWC HCD `_buffer_parse_bulk` assert on band-switch stop→start).
- Drain timeout: skip free, keep `pause_resubmit`, return `ESP_RTL_SDR_ERR_TIMEOUT`, state FAULT. `free_bulk_pool` also refuses while live. Uninstall clears stuck counter only after host teardown.
- Version bump **0.7.14**.

## Test plan
- [x] `tests\scripts\run_host_tests.ps1` → `RESULT passed=291 failed=0`
- [ ] Hardware: Tab5 band-switch / POCSAG stop→start (not run in this PR; no flash)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream stopping reliability by ensuring active transfers finish before resources are released.
  * Prevented stop-and-restart operations from triggering hardware controller errors.
  * Added timeout handling when transfers cannot complete; the device now reports a timeout and enters a fault state instead of risking unsafe cleanup.

* **Chores**
  * Updated the component and example application version to 0.7.14.
  * Updated release documentation and version references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->