### PR TITLE
fix: complete Blog V4 HF front-end routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+## 0.7.15 (2026-09-09)
+
+### Fixed — Blog V4 HF hardware routing (hardware acceptance pending)
+
+- Completes capture-derived Cable-2 (`R828D 0x06=0x38`) and RTL2832 GPIO5-low selection for HF; restores GPIO5-high and VHF/UHF input masks outside HF.
+- Composes GPIO0 Bias-T state with GPIO5 routing and keeps `GPOE=0x39`, so Bias-T changes cannot undo the selected RF path.
+- Composes manual/AUTO register-05 low bits with the HF/VHF/UHF input masks, preserving gain state across retunes and routing across gain changes.
+- Uses the same complete route application for startup, hot retune, gain/AUTO, and Bias-T, and marks the applied route valid only after every required write succeeds.
+- Selects the HF Cable-2 route at exactly 28.8 MHz while applying the 28.8 MHz LO offset only below that frequency.
+- Host tests and ESP-IDF compilation do not constitute physical reception acceptance; GPIO, raw-IQ, AM, Shortwave, VHF, and UHF tests remain open.
+
 ## 0.7.14 (2026-09-07)
 
 ### Changed

--- a/PROJECT_TRUTH.md
+++ b/PROJECT_TRUTH.md
@@ -6,8 +6,8 @@ wins for *what is true right now*.
 Same discipline as [TheOrc PROJECT_TRUTH](https://github.com/hardcoreerik/TheOrc):
 claims need evidence labels; oversell is a bug; retract rather than spin.
 
-Snapshot date: **2026-09-07**  
-Version: **0.7.14** (stop drains live URBs before free_bulk_pool; public windowed metrics/health; USB soak still operator work - not production-ready)
+Snapshot date: **2026-09-09**
+Version: **0.7.15** (Blog V4 HF/VHF/UHF route composition implemented; GPIO and RF acceptance still operator work - not production-ready)
 Local repo: `F:\Ai\ESP_RTL_SDR\`  
 Remote: **https://github.com/hardcoreerik/esp-rtl-sdr**  
 Open-source honesty: [docs/AI_DEVELOPMENT_DISCLOSURE.md](docs/AI_DEVELOPMENT_DISCLOSURE.md) ·
@@ -94,7 +94,7 @@ Product vision: **`docs/VISION.md`**. Silicon / DS map: **`docs/SILICON.md`**.
 | Tab5 / Waveshare Blog V4 RF | **Provenance** | OrcSDR |
 | Re-verify from *this* tree on hardware | **Planned** | |
 | Gain / bias-T hardware | **Implemented** (tables from PC USBPcap) | Lab 2026-08-12; **not** yet Hardware-verified from *this* tree on P4; no multimeter DC |
-| HF upconverter path CAP | **Implemented (0.7.7)** | RF&lt;28.8 MHz → tuner RF+28.8e6; CAP_HF_UPCONVERTER; FE soak open |
+| HF upconverter path CAP | **Implemented (routing corrected 0.7.15)** | RF&lt;28.8 MHz → tuner RF+28.8e6; RF≤28.8 MHz → Cable-2/GPIO5-low; host/build verified, physical FE soak open |
 | R828D stage gain / input / notches | **Planned** | |
 | Adaptive USB URB | **Planned** | |
 | Beacon ppm learn | **Planned** | |
@@ -124,6 +124,7 @@ Product vision: **`docs/VISION.md`**. Silicon / DS map: **`docs/SILICON.md`**.
 | **0.7.12** | Smoke SOAK evidence is scoped to the drain window (not pre-soak ring overflow) |
 | **0.7.13** | Public metrics_delta / health_from_window from metric snapshots (honest soak/app window) |
 | **0.7.14** | stop_stream_internal drains live URBs (shared with pause) before free_bulk_pool; avoids Tab5 HCD assert on band-switch stop→start |
+| **0.7.15** | Composed Blog V4 Cable-2/GPIO5/Bias-T/gain routing; physical GPIO and RF acceptance pending |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Make an RTL-SDR Blog V4 a first-class peripheral on ESP32-P4** — continuous I/Q over USB Host, with a real embedded driver API.
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
-![Status](https://img.shields.io/badge/version-0.7.14-green)
+![Status](https://img.shields.io/badge/version-0.7.15-green)
 [![GitHub](https://img.shields.io/badge/github-esp--rtl--sdr-black)](https://github.com/hardcoreerik/esp-rtl-sdr)
 ![Target](https://img.shields.io/badge/ESP32--P4-HS_USB-green)
 
@@ -246,9 +246,9 @@ Design contract: [`docs/API.md`](docs/API.md) · header: [`include/esp_rtl_sdr.h
 | `set_tuner_gain_mode(MANUAL\|AUTO)` | MANUAL ladder; AUTO measured R828D AGC (`CAP_GAIN_AUTO`, 0.7.8+). Streaming = async EP0. |
 | `set/get_rtl_agc` | RTL2832 digital AGC (`CAP_RTL_AGC`); not tuner AUTO. **get** = requested shadow, not readback. |
 | `set/get_bias_tee` | Measured SYS EP0 (CAP_BIAS_TEE); need claimed stream |
-| HF (0.7.7) | **500 kHz…1766 MHz**; RF&lt;28.8 MHz uses +28.8 MHz upconverter (`CAP_HF_UPCONVERTER`) |
+| HF (0.7.15 routing correction) | **500 kHz…1766 MHz**; RF&lt;28.8 MHz uses +28.8 MHz LO, RF≤28.8 MHz selects Cable-2 and GPIO5-low (`CAP_HF_UPCONVERTER`) |
 
-Evidence: [`docs/PHASE3_CAPTURE_REPORT.md`](docs/PHASE3_CAPTURE_REPORT.md), [`docs/AGC_IF_CAPTURE.md`](docs/AGC_IF_CAPTURE.md). P4 RF soak of HF FE / AUTO still open.
+Evidence: [`docs/PHASE3_CAPTURE_REPORT.md`](docs/PHASE3_CAPTURE_REPORT.md), [`docs/AGC_IF_CAPTURE.md`](docs/AGC_IF_CAPTURE.md), and the checked-in clean-room transfer table. The 0.7.15 routing composition is host/build verified only; P4 GPIO and RF acceptance remain open.
 
 ### Typical rates (macros)
 

--- a/docs/AI_DEVELOPMENT_DISCLOSURE.md
+++ b/docs/AI_DEVELOPMENT_DISCLOSURE.md
@@ -35,7 +35,7 @@ the outcome.**
 | Drop-in librtlsdr / `rtl-sdr.h` ABI | **No** — never a goal |
 | Every RTL2832U dongle works | **No** — profile-based; Blog V4 first |
 | All rates “P4 proven” | **No** — only 960k / 2.048M have **provenance** under OrcSDR; passport learns the rest **on your host** |
-| Re-soaked from *this* tree on hardware | **Open** — tracked in [PROJECT_TRUTH.md](../PROJECT_TRUTH.md) |
+| Re-soaked from *this* tree on hardware | **Open** — 0.7.15 HF routing is capture-derived and still needs GPIO/RF acceptance; tracked in [PROJECT_TRUTH.md](../PROJECT_TRUTH.md) |
 | Formal third-party security audit | **No** |
 
 If a README or release note sounds stronger than the table above, treat that as a

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -422,7 +422,7 @@ Named presets **ignore** `frequency_hz` in the stream config.
 | `NEED_FM` | FM-class: ~960k @ preferred LO |
 | `NEED_ADSB` | 1090 MHz, 2.048 MSPS |
 | `NEED_WX` | NOAA WX 162.400 MHz, 960k |
-| `NEED_HF` | Stores HF LO intent; full upconverter CAP still open |
+| `NEED_HF` | Stores HF LO intent; V4 routing is applied when streaming starts |
 | `NEED_MAX_STABLE` | Passport `best_stable_sps` if valid, else 2.048M |
 | `NEED_LISTEN` | Lowest-drop default: 960k, keep LO |
 

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -13,7 +13,7 @@ Desktop reference: **librtlsdr / rtl-sdr-blog**. Status matches `PROJECT_TRUTH.m
 | 8–9 | Tuner gain | modes / steps | Manual ladder + Tuner AUTO (`CAP_GAIN_AUTO`) + RTL AGC | **Done (0.7.8)** |
 | 11 | ppm | yes | software LO offset | **Done** |
 | 12 | Bias-T | common | Measured SYS EP0 (CAP_BIAS_TEE); DC re-soak open | **3 partial** |
-| 13 | Direct sampling / HF | forks | **HF upconverter CAP** (RF+28.8e6); not direct sampling | **Done (0.7.7)** |
+| 13 | Direct sampling / HF | forks | **HF upconverter CAP** (RF+28.8e6 below boundary; Cable-2/GPIO5 route corrected); not direct sampling | **Implemented (0.7.15), hardware acceptance open** |
 | 15 | Multi-device | index/serial | yes | **Done** |
 | 19 | Metrics | app-side | `get_metrics` | **Done (stronger)** |
 | 20 | Capability bits | weak | `get_capabilities` | **Done (stronger)** |

--- a/examples/p4_serial_smoke/CMakeLists.txt
+++ b/examples/p4_serial_smoke/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 
-# Pin app version so idf.py project_description is 0.7.14, not git-describe
+# Pin app version so idf.py project_description is 0.7.15, not git-describe
 # of an older tag.
-set(PROJECT_VER "0.7.14")
+set(PROJECT_VER "0.7.15")
 
 # IDF 5.5.4 defaults SDKCONFIG to ${CMAKE_SOURCE_DIR}/sdkconfig. -B only
 # changes the binary dir, so two URB images would share one config. Keep

--- a/examples/p4_serial_smoke/main/main.cpp
+++ b/examples/p4_serial_smoke/main/main.cpp
@@ -1,5 +1,5 @@
 /*
- * ESP-IDF Tab5 / P4 drop-in smoke for esp_rtl_sdr public API (v0.7.14).
+ * ESP-IDF Tab5 / P4 drop-in smoke for esp_rtl_sdr public API (v0.7.15).
  *
  * One USB host install per boot. URB layout is a Kconfig choice so A/B
  * (6x16 KiB vs 3x32 KiB) is two firmware images, not two installs.
@@ -156,7 +156,7 @@ static void check_pure_helpers(void)
     smoke_row("rate_4M_reject", !esp_rtl_sdr_is_rate_supported(4000000));
 
     const char *ver = esp_rtl_sdr_get_version_string();
-    smoke_row("version_0_7_14", ver != NULL && strcmp(ver, "0.7.14") == 0);
+    smoke_row("version_0_7_15", ver != NULL && strcmp(ver, "0.7.15") == 0);
 
     const uint32_t caps = esp_rtl_sdr_get_capabilities();
     smoke_row("cap_gain", (caps & ESP_RTL_SDR_CAP_GAIN) != 0);

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,5 +1,5 @@
 ## esp_rtl_sdr — ESP Component Registry metadata
-version: "0.7.14"
+version: "0.7.15"
 description: >
   Clean-room ESP-IDF USB Host client for RTL2832U-class SDR dongles.
   Blog V4 (R828D) profile first; profile-based expansion for other tuners.

--- a/include/esp_rtl_sdr.h
+++ b/include/esp_rtl_sdr.h
@@ -87,7 +87,7 @@ extern "C" {
 /** Semantic version of this public header / binary API. */
 #define ESP_RTL_SDR_VERSION_MAJOR 0
 #define ESP_RTL_SDR_VERSION_MINOR 7
-#define ESP_RTL_SDR_VERSION_PATCH 14
+#define ESP_RTL_SDR_VERSION_PATCH 15
 
 #define ESP_RTL_SDR_VERSION_NUMBER                                      \
     ((ESP_RTL_SDR_VERSION_MAJOR * 10000) +                              \
@@ -205,13 +205,13 @@ const char *esp_rtl_sdr_err_to_name(esp_err_t err);
 /**
  * Frequency policy (Hz) — Blog V4 full advertised span (public DS / product page).
  * Below HF_UPCONV_LO_HZ the driver programs the R828D at RF+28.8 MHz (built-in
- * SA612 upconverter) and selects the HF triplexer input.
+ * SA612 upconverter). The Cable-2 route remains selected through exactly 28.8 MHz.
  */
 #define ESP_RTL_SDR_FREQ_MIN_HZ        500000u
 #define ESP_RTL_SDR_FREQ_MAX_HZ        1766000000u
 /** Built-in HF upconverter LO (Blog V4 public: SA612 @ 28.8 MHz). */
 #define ESP_RTL_SDR_HF_UPCONV_LO_HZ    28800000u
-/** Triplexer band edges (public V4 product page): HF | VHF | UHF+. */
+/** Triplexer edges: HF is <= VHF_MIN_HZ; VHF begins immediately above it. */
 #define ESP_RTL_SDR_BAND_VHF_MIN_HZ    28800000u
 #define ESP_RTL_SDR_BAND_UHF_MIN_HZ    250000000u
 /** Quantization applied by retune_hz / start (Hz). */
@@ -576,8 +576,8 @@ esp_err_t esp_rtl_sdr_get_supported_rates(uint32_t *out_rates,
 bool esp_rtl_sdr_normalize_frequency(uint32_t in_hz, uint32_t *out_hz);
 
 /**
- * True if RF is in the Blog V4 HF upconverter band (RF < 28.8 MHz).
- * Public product page: SA612 LO 28.8 MHz; software adds the offset.
+ * True when the 28.8 MHz LO offset is required (RF < 28.8 MHz).
+ * At exactly 28.8 MHz the HF Cable-2 route is selected without adding the LO.
  */
 bool esp_rtl_sdr_frequency_uses_hf_upconverter(uint32_t rf_hz);
 
@@ -827,7 +827,7 @@ esp_err_t esp_rtl_sdr_select_device_serial(esp_rtl_sdr_handle_t handle, const ch
 
 /**
  * Apply a mission intent: sets preferred LO + sample rate (quantized).
- * Does not start streaming. NEED_HF stores HF LO; full upconverter CAP still open.
+ * Does not start streaming. NEED_HF stores HF LO; V4 routing is applied when streaming starts.
  * NEED_MAX_STABLE uses last successful passport best_stable_sps when valid.
  */
 esp_err_t esp_rtl_sdr_apply_need(esp_rtl_sdr_handle_t handle, esp_rtl_sdr_need_t need);

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "esp_rtl_sdr",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "description": "Clean-room ESP USB Host client for RTL2832U-class SDR (Blog V4 profile first)",
   "keywords": "sdr, rtl-sdr, rtl2832u, usb, esp32-p4, esp_rtl_sdr",
   "license": "AGPL-3.0-only",

--- a/private/measured_gain_bias_v4.hpp
+++ b/private/measured_gain_bias_v4.hpp
@@ -16,7 +16,7 @@
  *   SYS block:      wValue=0x30xx, wIndex=0x0210, data[0]=value
  *
  * Re-validated from decode TSV payloads: all 28 (reg05,reg07) pairs present;
- * bias ON/OFF clusters match kMeasuredV4BiasOn/Off exactly (3001 0x19 vs 0x18).
+ * bias ON/OFF clusters establish GPIO0 while band transitions establish GPIO5.
  */
 
 #include <cstddef>
@@ -30,6 +30,46 @@ struct MeasuredV4GainStep {
     uint8_t reg05; /**< measured via 0x0074 write pair {0x05, val} */
     uint8_t reg07; /**< measured via 0x0074 write pair {0x07, val} */
 };
+
+enum class MeasuredV4FrontendBand : uint8_t { HF, VHF, UHF };
+
+struct MeasuredV4FrontendPlan {
+    MeasuredV4FrontendBand band;
+    bool bias_tee;
+    uint8_t reg05_low_bits;
+    uint8_t reg05;
+    uint8_t reg06;
+    uint8_t gpd;
+    uint8_t gpoe;
+    uint8_t gpo;
+};
+
+/** Capture-derived Blog V4 route. Exactly 28.8 MHz remains on Cable-2. */
+constexpr MeasuredV4FrontendBand measured_v4_frontend_band(uint32_t rf_hz)
+{
+    return rf_hz <= 28800000u ? MeasuredV4FrontendBand::HF
+                              : (rf_hz >= 250000000u ? MeasuredV4FrontendBand::UHF
+                                                     : MeasuredV4FrontendBand::VHF);
+}
+
+constexpr MeasuredV4FrontendPlan measured_v4_frontend_plan(uint32_t rf_hz, bool bias_tee,
+                                                            uint8_t raw_reg05)
+{
+    const MeasuredV4FrontendBand band = measured_v4_frontend_band(rf_hz);
+    const uint8_t input = band == MeasuredV4FrontendBand::HF
+                              ? 0xa0
+                              : (band == MeasuredV4FrontendBand::UHF ? 0x80 : 0xe0);
+    const uint8_t low = raw_reg05 & 0x1f;
+    return {band,
+            bias_tee,
+            low,
+            static_cast<uint8_t>(input | low),
+            static_cast<uint8_t>(band == MeasuredV4FrontendBand::HF ? 0x38 : 0x30),
+            0x06,
+            0x39,
+            static_cast<uint8_t>((band == MeasuredV4FrontendBand::HF ? 0x18 : 0x38) |
+                                 (bias_tee ? 0x01 : 0x00))};
+}
 
 /**
  * Full ladder from SDR# RF Gain 0.0 → 49.6 dB (lab 2026-08-12).
@@ -96,30 +136,6 @@ constexpr uint16_t kMeasuredV4RtlAgcWvalue = 0x1920;
 constexpr uint16_t kMeasuredV4RtlAgcWindex = 0x0010;
 constexpr uint8_t kMeasuredV4RtlAgcOn = 0x25;
 constexpr uint8_t kMeasuredV4RtlAgcOff = 0x05;
-
-/**
- * Bias-T SYS sequence measured from rtl_biast clusters (toggle groups).
- * ON:  3001 data 0x19   OFF: 3001 data 0x18  (LSB differs)
- * Companion writes 3004/3003/3000 match every observed toggle cluster.
- */
-constexpr RtlControlRecord kMeasuredV4BiasOn[] = {
-    {0x3004, 0x0210, 0x40, 1, {0x06, 0, 0, 0, 0, 0, 0, 0}},
-    {0x3003, 0x0210, 0x40, 1, {0x19, 0, 0, 0, 0, 0, 0, 0}},
-    {0x3001, 0x0210, 0x40, 1, {0x19, 0, 0, 0, 0, 0, 0, 0}},
-    {0x3000, 0x0210, 0x40, 1, {0x20, 0, 0, 0, 0, 0, 0, 0}},
-};
-
-constexpr RtlControlRecord kMeasuredV4BiasOff[] = {
-    {0x3004, 0x0210, 0x40, 1, {0x06, 0, 0, 0, 0, 0, 0, 0}},
-    {0x3003, 0x0210, 0x40, 1, {0x19, 0, 0, 0, 0, 0, 0, 0}},
-    {0x3001, 0x0210, 0x40, 1, {0x18, 0, 0, 0, 0, 0, 0, 0}},
-    {0x3000, 0x0210, 0x40, 1, {0x20, 0, 0, 0, 0, 0, 0, 0}},
-};
-
-constexpr size_t kMeasuredV4BiasOnCount =
-    sizeof(kMeasuredV4BiasOn) / sizeof(kMeasuredV4BiasOn[0]);
-constexpr size_t kMeasuredV4BiasOffCount =
-    sizeof(kMeasuredV4BiasOff) / sizeof(kMeasuredV4BiasOff[0]);
 
 /** Build 0x0074 / 0x0610 write for IR register pair (measured encoding). */
 inline RtlControlRecord measured_v4_ir_reg_write(uint8_t reg, uint8_t value)

--- a/src/esp_rtl_sdr.cpp
+++ b/src/esp_rtl_sdr.cpp
@@ -178,6 +178,10 @@ struct esp_rtl_sdr_handle {
     bool bias_tee_want = false;
     bool rtl_agc_want = false;
     bool tuner_auto_applied = false; /* true after AUTO trio actually written */
+    uint8_t tuner_reg05_low_bits = 0x03;
+    uint8_t tuner_reg07 = 0x75;
+    MeasuredV4FrontendPlan frontend_applied{};
+    bool frontend_applied_valid = false;
 
     /** Sync-read pull ring (CU8 bytes). Filled by delivery task. */
     uint8_t *pull_buf = nullptr;
@@ -583,94 +587,77 @@ static esp_err_t run_records(esp_rtl_sdr_handle *h, const RtlControlRecord *tab,
     return ESP_OK;
 }
 
-static esp_err_t run_uhf_frontend(esp_rtl_sdr_handle *h)
+static const char *frontend_band_name(MeasuredV4FrontendBand band)
 {
-    constexpr RtlControlRecord kUhf[] = {
-        {0x0074, 0x0610, 0x40, 2, {0x17, 0x28}},
-        {0x0074, 0x0610, 0x40, 2, {0x1a, 0x68}},
-        {0x0074, 0x0610, 0x40, 2, {0x1b, 0x00}},
-        {0x0074, 0x0610, 0x40, 2, {0x05, 0x83}},
-        {0x0074, 0x0610, 0x40, 2, {0x0c, 0x6b}},
-    };
-    return run_records(h, kUhf, std::size(kUhf));
+    return band == MeasuredV4FrontendBand::HF
+               ? "HF"
+               : (band == MeasuredV4FrontendBand::UHF ? "UHF" : "VHF");
 }
 
-/**
- * HF triplexer path.
- * Full path writes reg05=0xa3 (measured init mid-transition family).
- * filters_only skips reg05 so CAP_GAIN ladder is not clobbered after gain EP0.
- */
-static esp_err_t run_hf_frontend(esp_rtl_sdr_handle *h, bool filters_only)
+/** Apply one complete capture-derived route; caller owns any bulk-pause window. */
+static esp_err_t run_band_frontend(esp_rtl_sdr_handle *h, uint32_t rf_hz,
+                                   uint8_t raw_reg05, uint8_t reg07, uint8_t reg0c,
+                                   bool bias_companion = false)
 {
-    constexpr RtlControlRecord kHfFull[] = {
-        {0x0074, 0x0610, 0x40, 2, {0x17, 0x20}},
-        {0x0074, 0x0610, 0x40, 2, {0x1a, 0x2a}},
-        {0x0074, 0x0610, 0x40, 2, {0x1b, 0x00}},
-        {0x0074, 0x0610, 0x40, 2, {0x05, 0xa3}},
-        {0x0074, 0x0610, 0x40, 2, {0x0c, 0x68}},
+    const MeasuredV4FrontendPlan plan =
+        measured_v4_frontend_plan(rf_hz, h->bias_tee_want, raw_reg05);
+    const bool uhf = plan.band == MeasuredV4FrontendBand::UHF;
+    const bool hf = plan.band == MeasuredV4FrontendBand::HF;
+    const RtlControlRecord records[] = {
+        measured_v4_ir_reg_write(0x17, uhf ? 0x28 : 0x20),
+        measured_v4_ir_reg_write(0x1a, uhf ? 0x68 : 0x2a),
+        measured_v4_ir_reg_write(0x1b, hf || uhf ? 0x00 : 0x34),
+        measured_v4_ir_reg_write(0x06, plan.reg06),
+        {0x3004, 0x0210, 0x40, 1, {plan.gpd, 0, 0, 0, 0, 0, 0, 0}},
+        {0x3003, 0x0210, 0x40, 1, {plan.gpoe, 0, 0, 0, 0, 0, 0, 0}},
+        {0x3001, 0x0210, 0x40, 1, {plan.gpo, 0, 0, 0, 0, 0, 0, 0}},
     };
-    constexpr RtlControlRecord kHfFilt[] = {
-        {0x0074, 0x0610, 0x40, 2, {0x17, 0x20}},
-        {0x0074, 0x0610, 0x40, 2, {0x1a, 0x2a}},
-        {0x0074, 0x0610, 0x40, 2, {0x1b, 0x00}},
-        {0x0074, 0x0610, 0x40, 2, {0x0c, 0x68}},
-    };
-    return filters_only ? run_records(h, kHfFilt, std::size(kHfFilt))
-                        : run_records(h, kHfFull, std::size(kHfFull));
+
+    h->frontend_applied_valid = false;
+    esp_err_t err = run_records(h, records, std::size(records));
+    if (err == ESP_OK && bias_companion) {
+        constexpr RtlControlRecord companion =
+            {0x3000, 0x0210, 0x40, 1, {0x20, 0, 0, 0, 0, 0, 0, 0}};
+        err = run_record(h, companion, false);
+    }
+    if (err == ESP_OK) {
+        err = run_record(h, measured_v4_ir_reg_write(0x05, plan.reg05), false);
+    }
+    if (err == ESP_OK) {
+        err = run_record(h, measured_v4_ir_reg_write(0x07, reg07), false);
+    }
+    if (err == ESP_OK) {
+        err = run_record(h, measured_v4_ir_reg_write(0x0c, reg0c), false);
+    }
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "front-end route failed rf=%u band=%s: %s",
+                 static_cast<unsigned>(rf_hz), frontend_band_name(plan.band),
+                 esp_rtl_sdr_err_to_name(err));
+        return err;
+    }
+
+    h->tuner_reg05_low_bits = plan.reg05_low_bits;
+    h->tuner_reg07 = reg07;
+    h->frontend_applied = plan;
+    h->frontend_applied_valid = true;
+    ESP_LOGI(TAG,
+             "front-end route rf=%u band=%s r6=%02x r5=%02x gpio=%02x bias=%d reg05_low=%02x",
+             static_cast<unsigned>(rf_hz), frontend_band_name(plan.band), plan.reg06,
+             plan.reg05, plan.gpo, plan.bias_tee ? 1 : 0, plan.reg05_low_bits);
+    return ESP_OK;
 }
 
-/** VHF restore after HF/UHF (measured init tail family, reg05=0xe3). */
-static esp_err_t run_vhf_frontend(esp_rtl_sdr_handle *h, bool filters_only)
-{
-    constexpr RtlControlRecord kVhfFull[] = {
-        {0x0074, 0x0610, 0x40, 2, {0x17, 0x20}},
-        {0x0074, 0x0610, 0x40, 2, {0x1a, 0x2a}},
-        {0x0074, 0x0610, 0x40, 2, {0x1b, 0x34}},
-        {0x0074, 0x0610, 0x40, 2, {0x05, 0xe3}},
-        {0x0074, 0x0610, 0x40, 2, {0x0c, 0x68}},
-    };
-    constexpr RtlControlRecord kVhfFilt[] = {
-        {0x0074, 0x0610, 0x40, 2, {0x17, 0x20}},
-        {0x0074, 0x0610, 0x40, 2, {0x1a, 0x2a}},
-        {0x0074, 0x0610, 0x40, 2, {0x1b, 0x34}},
-        {0x0074, 0x0610, 0x40, 2, {0x0c, 0x68}},
-    };
-    return filters_only ? run_records(h, kVhfFilt, std::size(kVhfFilt))
-                        : run_records(h, kVhfFull, std::size(kVhfFull));
-}
-
-/** Select triplexer band for user RF (not tuner LO). */
 static esp_err_t run_band_frontend(esp_rtl_sdr_handle *h, uint32_t rf_hz)
 {
-    if (rf_hz < ESP_RTL_SDR_BAND_VHF_MIN_HZ) {
-        ESP_LOGI(TAG, "band FE HF rf=%u", static_cast<unsigned>(rf_hz));
-        return run_hf_frontend(h, false);
-    }
-    if (rf_hz >= ESP_RTL_SDR_BAND_UHF_MIN_HZ) {
-        ESP_LOGI(TAG, "band FE UHF rf=%u", static_cast<unsigned>(rf_hz));
-        return run_uhf_frontend(h);
-    }
-    ESP_LOGI(TAG, "band FE VHF rf=%u", static_cast<unsigned>(rf_hz));
-    return run_vhf_frontend(h, false);
+    const bool uhf = measured_v4_frontend_band(rf_hz) == MeasuredV4FrontendBand::UHF;
+    const uint8_t reg0c = (h->tuner_auto_applied || uhf) ? kMeasuredV4TunerAgcReg0c
+                                                        : kMeasuredV4GainReg0c;
+    return run_band_frontend(h, rf_hz, h->tuner_reg05_low_bits, h->tuner_reg07, reg0c);
 }
 
-/** After gain EP0: refresh band filters without clobbering reg05 gain ladder. */
-static esp_err_t run_band_frontend_after_gain(esp_rtl_sdr_handle *h, uint32_t rf_hz)
+static uint32_t frontend_rf_hz(const esp_rtl_sdr_handle *h)
 {
-    if (rf_hz < ESP_RTL_SDR_BAND_VHF_MIN_HZ) {
-        return run_hf_frontend(h, true);
-    }
-    if (rf_hz >= ESP_RTL_SDR_BAND_UHF_MIN_HZ) {
-        /* UHF measured path includes reg05 — skip full rewrite; filters only. */
-        constexpr RtlControlRecord kUhfFilt[] = {
-            {0x0074, 0x0610, 0x40, 2, {0x17, 0x28}},
-            {0x0074, 0x0610, 0x40, 2, {0x1a, 0x68}},
-            {0x0074, 0x0610, 0x40, 2, {0x1b, 0x00}},
-            {0x0074, 0x0610, 0x40, 2, {0x0c, 0x6b}},
-        };
-        return run_records(h, kUhfFilt, std::size(kUhfFilt));
-    }
-    return run_vhf_frontend(h, true);
+    return h->frequency_hz != 0 ? h->frequency_hz : h->preferred_frequency_hz;
 }
 
 static void run_cleanup_best_effort(esp_rtl_sdr_handle *h)
@@ -869,6 +856,7 @@ static esp_err_t apply_pending_retune(esp_rtl_sdr_handle *h)
     const uint32_t tune_hz =
         (h->pending_retune_hz != 0) ? h->pending_retune_hz : freq;
 
+    h->frontend_applied_valid = false;
     esp_err_t err = run_tune(h, tune_hz);
     if (err == ESP_OK) {
         err = run_band_frontend(h, tune_hz);
@@ -884,7 +872,8 @@ static esp_err_t apply_pending_retune(esp_rtl_sdr_handle *h)
                  static_cast<unsigned>(tune_hz),
                  static_cast<unsigned>(esp_rtl_sdr_tuner_frequency_hz(tune_hz)));
     } else {
-        ESP_LOGW(TAG, "hot retune EP0 failed: %s (keep LO)", esp_rtl_sdr_err_to_name(err));
+        ESP_LOGW(TAG, "hot retune EP0 failed: %s (PLL/route may be partially applied)",
+                 esp_rtl_sdr_err_to_name(err));
         if (h->pending_retune_hz == tune_hz) {
             h->pending_retune_hz = 0;
         }
@@ -1910,6 +1899,7 @@ static esp_err_t stop_stream_internal(esp_rtl_sdr_handle *h, uint32_t timeout_ms
     h->state = ESP_RTL_SDR_STATE_STOPPING;
     h->pause_resubmit = true;
     h->streaming = false;
+    h->frontend_applied_valid = false;
     h->pending_retune_hz = 0;
     h->pending_gain = false;
     h->pending_gain_mode = false;
@@ -3130,24 +3120,18 @@ esp_err_t esp_rtl_sdr_probe_rates(esp_rtl_sdr_handle_t handle,
 /* Phase 3 — gain / bias (clean-room measured Blog V4 2026-08-12)             */
 /* -------------------------------------------------------------------------- */
 
-/** IR gain writes only (caller owns bulk pause). Retries full trio on STALL/USB. */
+/** Apply manual gain and the current route together (caller owns bulk pause). */
 static esp_err_t apply_gain_records(esp_rtl_sdr_handle *h, int tenth_db, int *applied_tenth)
 {
     const size_t idx = measured_v4_nearest_gain_index(tenth_db);
     const MeasuredV4GainStep &st = kMeasuredV4GainSteps[idx];
-    const RtlControlRecord w05 = measured_v4_ir_reg_write(0x05, st.reg05);
-    const RtlControlRecord w07 = measured_v4_ir_reg_write(0x07, st.reg07);
-    const RtlControlRecord w0c = measured_v4_ir_reg_write(0x0c, kMeasuredV4GainReg0c);
+    const uint32_t rf_hz = frontend_rf_hz(h);
+    const bool uhf = measured_v4_frontend_band(rf_hz) == MeasuredV4FrontendBand::UHF;
+    const uint8_t reg0c = uhf ? kMeasuredV4TunerAgcReg0c : kMeasuredV4GainReg0c;
 
     esp_err_t err = ESP_FAIL;
     for (int pass = 0; pass < 3; ++pass) {
-        err = run_record(h, w05, false);
-        if (err == ESP_OK) {
-            err = run_record(h, w07, false);
-        }
-        if (err == ESP_OK) {
-            err = run_record(h, w0c, false);
-        }
+        err = run_band_frontend(h, rf_hz, st.reg05, st.reg07, reg0c);
         if (err == ESP_OK) {
             break;
         }
@@ -3163,26 +3147,14 @@ static esp_err_t apply_gain_records(esp_rtl_sdr_handle *h, int tenth_db, int *ap
     return ESP_OK;
 }
 
-/** Tuner AGC AUTO trio (caller owns bulk pause). Do not run band FE after — it
- *  would clobber measured reg0c=0x6B back to the manual 0x68 on VHF/HF. */
+/** Apply tuner AUTO and the current route together (caller owns bulk pause). */
 static esp_err_t apply_tuner_agc_auto_records(esp_rtl_sdr_handle *h)
 {
-    const RtlControlRecord w05 =
-        measured_v4_ir_reg_write(0x05, kMeasuredV4TunerAgcReg05);
-    const RtlControlRecord w07 =
-        measured_v4_ir_reg_write(0x07, kMeasuredV4TunerAgcReg07);
-    const RtlControlRecord w0c =
-        measured_v4_ir_reg_write(0x0c, kMeasuredV4TunerAgcReg0c);
-
     esp_err_t err = ESP_FAIL;
+    const uint32_t rf_hz = frontend_rf_hz(h);
     for (int pass = 0; pass < 3; ++pass) {
-        err = run_record(h, w05, false);
-        if (err == ESP_OK) {
-            err = run_record(h, w07, false);
-        }
-        if (err == ESP_OK) {
-            err = run_record(h, w0c, false);
-        }
+        err = run_band_frontend(h, rf_hz, kMeasuredV4TunerAgcReg05,
+                                kMeasuredV4TunerAgcReg07, kMeasuredV4TunerAgcReg0c);
         if (err == ESP_OK) {
             return ESP_OK;
         }
@@ -3210,21 +3182,18 @@ static esp_err_t apply_rtl_agc_records(esp_rtl_sdr_handle *h, bool enable)
     return err;
 }
 
-/** SYS bias sequence only (caller owns bulk pause). Settle after GPIO writes. */
+/** Apply Bias-T and the current route together (caller owns bulk pause). */
 static esp_err_t apply_bias_records(esp_rtl_sdr_handle *h, bool enable)
 {
-    const RtlControlRecord *tab = enable ? kMeasuredV4BiasOn : kMeasuredV4BiasOff;
-    const size_t n = enable ? kMeasuredV4BiasOnCount : kMeasuredV4BiasOffCount;
-
     esp_err_t err = ESP_OK;
+    const uint32_t rf_hz = frontend_rf_hz(h);
     for (int pass = 0; pass < 2; ++pass) {
-        err = ESP_OK;
-        for (size_t i = 0; i < n; ++i) {
-            err = run_record(h, tab[i], false);
-            if (err != ESP_OK) {
-                break;
-            }
-        }
+        const bool uhf = measured_v4_frontend_band(rf_hz) == MeasuredV4FrontendBand::UHF;
+        const uint8_t reg0c = (h->tuner_auto_applied || uhf) ? kMeasuredV4TunerAgcReg0c
+                                                            : kMeasuredV4GainReg0c;
+        h->bias_tee_want = enable;
+        err = run_band_frontend(h, rf_hz, h->tuner_reg05_low_bits,
+                                h->tuner_reg07, reg0c, true);
         if (err == ESP_OK) {
             /* SYS GPIO path needs a beat before IR gain or bulk resume. */
             vTaskDelay(pdMS_TO_TICKS(40));
@@ -3306,7 +3275,6 @@ static esp_err_t apply_pending_sideband_ep0(esp_rtl_sdr_handle *h)
             h->gain_mode = ESP_RTL_SDR_GAIN_MODE_MANUAL;
             h->tuner_auto_applied = false;
             ESP_LOGI(TAG, "tuner gain applied %d (0.1 dB) [async]", applied);
-            (void)run_band_frontend_after_gain(h, h->frequency_hz);
         } else {
             ESP_LOGW(TAG, "tuner gain EP0 failed req=%d: %s", tenth,
                      esp_rtl_sdr_err_to_name(gerr));
@@ -3385,7 +3353,6 @@ static esp_err_t apply_measured_v4_gain_mode(esp_rtl_sdr_handle *h,
     if (err == ESP_OK) {
         h->gain_tenth_db = applied;
         h->tuner_auto_applied = false;
-        (void)run_band_frontend_after_gain(h, h->frequency_hz);
     }
     return err;
 }

--- a/tests/host/test_policy.cpp
+++ b/tests/host/test_policy.cpp
@@ -160,6 +160,99 @@ static void test_measured_agc_tables(void)
     EXPECT_EQ_U(dem.data[0], 0x25);
 }
 
+static void test_v4_frontend_composition(void)
+{
+    struct BandCase {
+        uint32_t hz;
+        MeasuredV4FrontendBand band;
+        uint8_t r6;
+        uint8_t r5;
+    };
+    constexpr BandCase cases[] = {
+        {1120000u, MeasuredV4FrontendBand::HF, 0x38, 0xa3},
+        {10000000u, MeasuredV4FrontendBand::HF, 0x38, 0xa3},
+        {28799999u, MeasuredV4FrontendBand::HF, 0x38, 0xa3},
+        {28800000u, MeasuredV4FrontendBand::HF, 0x38, 0xa3},
+        {28800001u, MeasuredV4FrontendBand::VHF, 0x30, 0xe3},
+        {100000000u, MeasuredV4FrontendBand::VHF, 0x30, 0xe3},
+        {249999999u, MeasuredV4FrontendBand::VHF, 0x30, 0xe3},
+        {250000000u, MeasuredV4FrontendBand::UHF, 0x30, 0x83},
+        {1090000000u, MeasuredV4FrontendBand::UHF, 0x30, 0x83},
+    };
+    for (const BandCase &c : cases) {
+        const auto p = measured_v4_frontend_plan(c.hz, false, 0x03);
+        EXPECT_EQ_U((int)p.band, (int)c.band);
+        EXPECT_EQ_U(p.reg06, c.r6);
+        EXPECT_EQ_U(p.reg05, c.r5);
+        EXPECT_EQ_U(p.gpd, 0x06);
+        EXPECT_EQ_U(p.gpoe, 0x39);
+    }
+
+    for (const uint32_t hz : {1120000u, 100000000u, 1090000000u}) {
+        const bool hf = measured_v4_frontend_band(hz) == MeasuredV4FrontendBand::HF;
+        const auto off = measured_v4_frontend_plan(hz, false, 0xf7);
+        const auto on = measured_v4_frontend_plan(hz, true, 0xf7);
+        EXPECT_EQ_U(off.gpo, hf ? 0x18 : 0x38);
+        EXPECT_EQ_U(on.gpo, hf ? 0x19 : 0x39);
+        EXPECT_EQ_U(off.gpo ^ on.gpo, 0x01);
+        EXPECT_EQ_U(off.reg05 & 0x1f, 0x17);
+        EXPECT_EQ_U(on.reg05, off.reg05);
+    }
+
+    EXPECT_EQ_U(measured_v4_frontend_plan(1120000u, false, 0xf7).reg05, 0xb7);
+    EXPECT_EQ_U(measured_v4_frontend_plan(100000000u, false, 0xf7).reg05, 0xf7);
+    EXPECT_EQ_U(measured_v4_frontend_plan(1090000000u, false, 0xf7).reg05, 0x97);
+    EXPECT_EQ_U(measured_v4_frontend_plan(1120000u, false, kMeasuredV4TunerAgcReg05)
+                    .reg05,
+                0xa8);
+    EXPECT_EQ_U(measured_v4_frontend_plan(100000000u, false, kMeasuredV4TunerAgcReg05)
+                    .reg05,
+                0xe8);
+    EXPECT_EQ_U(measured_v4_frontend_plan(1090000000u, false, kMeasuredV4TunerAgcReg05)
+                    .reg05,
+                0x88);
+
+    /* OFF -> ON -> OFF changes only GPIO0, including while HF owns GPIO5. */
+    const auto bias_off = measured_v4_frontend_plan(1120000u, false, 0xf0);
+    const auto bias_on = measured_v4_frontend_plan(1120000u, true, bias_off.reg05_low_bits);
+    const auto bias_off_again =
+        measured_v4_frontend_plan(1120000u, false, bias_on.reg05_low_bits);
+    EXPECT_EQ_U(bias_off.gpo, 0x18);
+    EXPECT_EQ_U(bias_on.gpo, 0x19);
+    EXPECT_EQ_U(bias_off_again.gpo, bias_off.gpo);
+    EXPECT_EQ_U(bias_off_again.reg05, bias_off.reg05);
+
+    /* VHF -> HF -> VHF and HF -> UHF -> HF preserve gain and Bias-T. */
+    const auto vhf = measured_v4_frontend_plan(100000000u, true, 0xf7);
+    const auto hf_from_vhf =
+        measured_v4_frontend_plan(1120000u, true, vhf.reg05_low_bits);
+    const auto vhf_return =
+        measured_v4_frontend_plan(100000000u, true, hf_from_vhf.reg05_low_bits);
+    const auto uhf_from_hf =
+        measured_v4_frontend_plan(1090000000u, true, hf_from_vhf.reg05_low_bits);
+    const auto hf_from_uhf =
+        measured_v4_frontend_plan(1120000u, true, uhf_from_hf.reg05_low_bits);
+    EXPECT_EQ_U(vhf.reg05, vhf_return.reg05);
+    EXPECT_EQ_U(hf_from_vhf.reg05, hf_from_uhf.reg05);
+    EXPECT_EQ_U(vhf.gpo ^ hf_from_vhf.gpo, 0x20);
+    EXPECT_EQ_U(uhf_from_hf.gpo ^ hf_from_uhf.gpo, 0x20);
+    EXPECT_EQ_U(vhf.gpo & 0x01, hf_from_uhf.gpo & 0x01);
+    EXPECT_EQ_U(uhf_from_hf.gpo & 0x01, hf_from_uhf.gpo & 0x01);
+
+    /* HF manual gain changes and manual -> AUTO retain the HF input mask. */
+    const auto hf_manual_low = measured_v4_frontend_plan(1120000u, false, 0xf0);
+    const auto hf_manual_high = measured_v4_frontend_plan(1120000u, false, 0xf7);
+    const auto hf_auto =
+        measured_v4_frontend_plan(1120000u, false, kMeasuredV4TunerAgcReg05);
+    EXPECT_EQ_U(hf_manual_low.reg05, 0xb0);
+    EXPECT_EQ_U(hf_manual_high.reg05, 0xb7);
+    EXPECT_EQ_U(hf_auto.reg05, 0xa8);
+
+    /* At 28.8 MHz Cable-2 remains selected, but no LO offset is added. */
+    EXPECT_TRUE(!esp_rtl_sdr_frequency_uses_hf_upconverter(28800000u));
+    EXPECT_EQ_U(esp_rtl_sdr_tuner_frequency_hz(28800000u), 28800000u);
+}
+
 static void test_callback_reentry_is_task_local(void)
 {
     const void *delivery = reinterpret_cast<const void *>(0x1000);
@@ -692,6 +785,7 @@ int main(void)
     test_version();
     test_capabilities();
     test_measured_agc_tables();
+    test_v4_frontend_composition();
     test_callback_reentry_is_task_local();
     test_delivery_mode_helpers();
     test_rate_windows();


### PR DESCRIPTION
## Summary

Completes the RTL-SDR Blog V4 HF hardware route in the first-party `esp-rtl-sdr` driver and prepares version 0.7.15.

The existing driver already translated RF below 28.8 MHz to the correct R828D tuner frequency. The missing piece was the physical signal path: runtime HF tuning did not fully select R828D Cable-2 or drive RTL2832 GPIO5 low for the V4 upconverter. USB streaming and PLL tuning could therefore succeed while AM Broadcast and Shortwave RF remained disconnected from the tuner.

## Clean-room provenance

This implementation is derived from our first-party USB captures and existing first-party transfer tables. The public RTL-SDR Blog V4 driver and public datasheet were used only to corroborate observable hardware behavior. No source structure, code, comments, or implementation was copied.

Capture-derived states used here include:

- HF: R828D R6 `0x38`, final R5 upper mask `0xA0`, RTL2832 GPIO output `0x18` with Bias-T off
- VHF: R828D R6 `0x30`, R5 upper mask `0xE0`, GPIO output `0x38` with Bias-T off
- UHF: R828D R6 `0x30`, R5 upper mask `0x80`, GPIO output `0x38` with Bias-T off
- Bias-T changes GPIO0 only, producing `0x18/0x19` in HF and `0x38/0x39` outside HF
- GPIO output enable remains `0x39`; GPD remains `0x06`

## Implementation

- Adds one private, pure front-end state composer for HF/VHF/UHF, Bias-T, R5, R6, GPD, GPOE, and GPO values.
- Uses one complete route-application path for initial startup, hot retuning, manual gain, tuner AUTO gain, and Bias-T.
- Preserves the active lower five R5 gain/mode bits while applying the appropriate band input mask.
- Prevents Bias-T changes from undoing GPIO5 upconverter selection.
- Tracks desired state separately from the last fully applied state.
- Marks the applied route valid only after every required control write succeeds.
- Keeps `ESP_RTL_SDR_EVT_RETUNED` gated on both successful PLL tuning and successful route application.
- Replaces the inaccurate retune failure wording that previously implied the LO necessarily remained unchanged.
- Selects the HF Cable-2 route at exactly 28.8 MHz while adding the 28.8 MHz LO offset only below that boundary.
- Adds concise route diagnostics for RF, band, R6, composed R5, GPIO, Bias-T, and lower R5 state.
- Updates public metadata and truth documentation to 0.7.15 without claiming hardware acceptance.

No public API or ABI was added.

## Tests and builds

Host commands:

```powershell
cmake -S tests/host -B tests/host/build -DCMAKE_BUILD_TYPE=Debug
cmake --build tests/host/build --config Debug
ctest --test-dir tests/host/build -C Debug --output-on-failure
.\tests\host\build\Debug\esp_rtl_sdr_host_tests.exe
```

Results:

- CTest: 1/1 passed
- Direct assertions: 372 passed, 0 failed
- Coverage includes AM 1.120 MHz, Shortwave 10 MHz, both band boundaries, VHF/UHF representatives, R6, GPIO composition, Bias-T off/on/off, manual gain, AUTO gain, and VHF/HF/UHF round trips.
- `git diff --check`: passed
- Version/truth metadata equivalent checks: passed for 0.7.15
- No sanitizer configuration exists in the repository, so none was invented for this change.

ESP-IDF compilation:

```powershell
cd examples/p4_serial_smoke
idf.py build
```

Result:

- ESP-IDF 5.5.4 ESP32-P4 smoke build passed, 1147/1147 steps.
- Application binary size: `0x57c80`; 66% of the smallest app partition remained free.
- Nothing was flashed and no serial port was accessed.

## Hardware acceptance remains open

This PR proves source composition, host policy behavior, and ESP-IDF compilation. It does not yet prove physical reception.

Before merge/release acceptance, the later hardware pass should independently verify:

- 1.120 MHz AM and 10 MHz Shortwave select HF with R6 `0x38` and GPIO5 low.
- Approximately 100 MHz restores VHF routing.
- 1090 MHz restores UHF routing.
- Bias-T off/on/off changes GPIO0 without changing GPIO5.
- Manual and AUTO gain changes preserve the selected RF input.
- A known or injected HF carrier is visible in raw IQ before evaluating decoded audio.
- AM audio, Shortwave, FM restoration, and UHF/ADS-B restoration are accepted as separate gates.
- Repeated HF/VHF/UHF transitions do not cause USB stalls, crashes, or silent route loss.

The observed transient R5 `0x83` before final `0xA3` was not added because current capture evidence does not establish that it is a required break-before-make transition. The implementation uses the smallest sequence consistent with confirmed final captured states. Existing notch behavior is intentionally unchanged pending a focused first-party capture sweep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated Blog V4 HF frontend routing, including Cable-2/GPIO5 selection, Bias-T handling, gain composition, and the 28.8 MHz boundary.
  - V4 routing is applied when streaming starts and preserved across gain and band changes.
- **Bug Fixes**
  - Corrected HF routing and register composition for low-frequency reception.
- **Documentation**
  - Updated capability, API, project status, and version documentation for release 0.7.15.
  - Hardware GPIO and RF acceptance remains pending.
- **Tests**
  - Added host-policy coverage for routing, Bias-T transitions, gain behavior, and boundary frequencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->