### PR TITLE
Add provisional Nooelec NESDR SMArt v5 profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Added
+
+- **Nooelec NESDR SMArt v5 R820T2/R860 profile scaffold:** accept explicit
+  `Nooelec` / `NESDR SMArt v5` USB descriptors on the shared RTL2832U
+  `0bda:2838` identity, map R82xx tuner-control records from the Blog V4 R828D
+  I²C value `0x74` to the R820T2/R860 value `0x34`, and reject Nooelec HF
+  requests below 24 MHz until direct sampling has measured support. This is
+  build/host-test verified only; physical Nooelec + P4 soak is still required
+  before a release can claim hardware support.
+
 ## 0.7.14 (2026-09-07)
 
 ### Changed

--- a/PROJECT_TRUTH.md
+++ b/PROJECT_TRUTH.md
@@ -67,7 +67,7 @@ Product vision: **`docs/VISION.md`**. Silicon / DS map: **`docs/SILICON.md`**.
 | Area | State | Boundary |
 |---|---|---|
 | Lifecycle install/start/stop/uninstall | **Implemented** | |
-| Continuous bulk IQ (multi-URB) | **Implemented** | Blog V4 profile |
+| Continuous bulk IQ (multi-URB) | **Implemented** | Blog V4 profile; Nooelec SMArt v5 R820T2/R860 profile scaffold is code/host-test only until P4 hardware soak |
 | In-stream `retune_hz` | **Implemented** | Drain bulk before EP0; **async from callback** (0.7.3) |
 | Metrics | **Implemented** | `get_metrics` |
 | Continuous sample rates (hardware windows) | **Implemented** | 225–300k ∪ 900k–3.2M + quantize → exact |
@@ -89,7 +89,8 @@ Product vision: **`docs/VISION.md`**. Silicon / DS map: **`docs/SILICON.md`**.
 | Sync `read()` | **Implemented** | |
 | Delivery modes BOTH/CALLBACK/READ + lazy pull ring | **Implemented** | 0.7.4; CAP_DELIVERY_MODE |
 | Multi-device select | **Implemented** | |
-| Blog V4 filter `0bda:2838` | **Implemented** | |
+| Blog V4 filter `0bda:2838` | **Implemented** | Exact `RTLSDRBlog` / `Blog V4` descriptors |
+| Nooelec NESDR SMArt v5 filter `0bda:2838` | **Implemented (unverified)** | Exact `Nooelec` / `NESDR SMArt v5` descriptors; R820T2/R860 tuner records use I²C `0x34`; HF/direct sampling below 24 MHz rejected |
 | Dual-core USB/delivery | **Implemented** | |
 | Tab5 / Waveshare Blog V4 RF | **Provenance** | OrcSDR |
 | Re-verify from *this* tree on hardware | **Planned** | |

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # esp_rtl_sdr
 
-**Make an RTL-SDR Blog V4 a first-class peripheral on ESP32-P4** — continuous I/Q over USB Host, with a real embedded driver API.
+**Make RTL2832U SDR dongles first-class peripherals on ESP32-P4** — continuous I/Q over USB Host, with a real embedded driver API.
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
 ![Status](https://img.shields.io/badge/version-0.7.14-green)
 [![GitHub](https://img.shields.io/badge/github-esp--rtl--sdr-black)](https://github.com/hardcoreerik/esp-rtl-sdr)
 ![Target](https://img.shields.io/badge/ESP32--P4-HS_USB-green)
 
-**Not a librtlsdr port.** Clean-room Blog V4 USB profile · stand-alone ESP-IDF component · fail-closed lifecycle  
+**Not a librtlsdr port.** Clean-room Blog V4 USB profile · provisional Nooelec SMArt v5 R820T2/R860 profile · stand-alone ESP-IDF component · fail-closed lifecycle
 
 **Status authority:** [`PROJECT_TRUTH.md`](PROJECT_TRUTH.md) wins if anything here disagrees. This is **0.x** — early, public, honest.
 
@@ -66,7 +66,7 @@ We are **not** chasing full librtlsdr feature parity (tuner IF filter still open
 | Item | Notes |
 |---|---|
 | **MCU** | **ESP32-P4** with High-Speed USB Host (e.g. M5Stack Tab5, Waveshare P4 kit) |
-| **Dongle** | **RTL-SDR Blog V4** — USB **`0bda:2838`**, mfg/product strings `RTLSDRBlog` / `Blog V4` |
+| **Dongle** | **RTL-SDR Blog V4** — USB **`0bda:2838`**, mfg/product strings `RTLSDRBlog` / `Blog V4`. Unreleased builds also admit explicit **Nooelec NESDR SMArt v5** descriptors for R820T2/R860 VHF/UHF testing; HF/direct sampling is not claimed. |
 | **Tooling** | ESP-IDF **≥ 5.5** with `esp32p4` support (OrcSDR Tab5 uses 5.5.4) |
 | **Antenna** | For RF; compile/smoke works without RF |
 
@@ -88,7 +88,7 @@ idf.py build
 idf.py -p PORT flash monitor
 ```
 
-Plug the Blog V4 into the P4 **USB Host** port (not the flash/UART port).
+Plug the Blog V4, or a Nooelec NESDR SMArt v5 when testing the unreleased R820T2/R860 profile, into the P4 **USB Host** port (not the flash/UART port).
 
 - **No dongle:** helpers + install should run; `start` → `NO_DEVICE` is OK.  
 - **With dongle:** stream, optional `read()`, health logs, passport if the example runs it.
@@ -213,7 +213,7 @@ Design contract: [`docs/API.md`](docs/API.md) · header: [`include/esp_rtl_sdr.h
 | `is_rate_supported` · `get_supported_rates` | Policy / UI lists |
 | `set/get_freq_correction` | Software ppm LO offset (±200) |
 | `apply_need` | `NEED_FM` · `NEED_ADSB` · `NEED_WX` · `NEED_HF` · `NEED_MAX_STABLE` · `NEED_LISTEN` |
-| HF LO map | RF &lt; 28.8 MHz → tuner RF+28.8 MHz (`CAP_HF_UPCONVERTER`, **0.7.7+**) |
+| HF LO map | Blog V4 RF &lt; 28.8 MHz → tuner RF+28.8 MHz (`CAP_HF_UPCONVERTER`, **0.7.7+**). Nooelec SMArt v5 HF/direct sampling is not implemented; requests below 24 MHz fail closed. |
 
 ### Data path
 

--- a/src/esp_rtl_sdr.cpp
+++ b/src/esp_rtl_sdr.cpp
@@ -51,8 +51,18 @@ static constexpr UBaseType_t kDeliveryPrio = 18;
 
 static constexpr uint16_t kVid = ESP_RTL_SDR_USB_VID;
 static constexpr uint16_t kPid = ESP_RTL_SDR_USB_PID;
-static constexpr char kMfg[] = "RTLSDRBlog";
-static constexpr char kProduct[] = "Blog V4";
+static constexpr char kBlogV4Mfg[] = "RTLSDRBlog";
+static constexpr char kBlogV4Product[] = "Blog V4";
+static constexpr char kNooelecMfg[] = "Nooelec";
+static constexpr char kNooelecSmartV5Product[] = "NESDR SMArt v5";
+static constexpr uint16_t kBlogV4TunerI2cValue = 0x0074;
+static constexpr uint16_t kR820T2TunerI2cValue = 0x0034;
+static constexpr uint32_t kR820T2NativeMinHz = 24000000u;
+
+enum class RtlHardwareProfile : uint8_t {
+    BlogV4 = 0,
+    NooelecSmartV5 = 1,
+};
 
 /** Extra high-band steps when passport recommended_only == false. */
 static const uint32_t kPassportExtraRates[] = {
@@ -62,6 +72,7 @@ static const uint32_t kPassportExtraRates[] = {
 struct DeviceCandidate {
     uint8_t addr = 0;
     esp_rtl_sdr_device_info_t info{};
+    RtlHardwareProfile profile = RtlHardwareProfile::BlogV4;
     bool valid = false;
 };
 
@@ -80,6 +91,7 @@ struct esp_rtl_sdr_handle {
     SemaphoreHandle_t lock = nullptr;
     esp_rtl_sdr_config_t cfg{};
     esp_rtl_sdr_device_info_t info{};
+    RtlHardwareProfile profile = RtlHardwareProfile::BlogV4;
     esp_rtl_sdr_metrics_t metrics{};
     esp_rtl_sdr_state_t state = ESP_RTL_SDR_STATE_UNINSTALLED;
     esp_err_t last_error = ESP_OK;
@@ -473,11 +485,33 @@ static esp_err_t ctrl_submit(esp_rtl_sdr_handle *h, uint8_t bm, uint8_t bRequest
     return final_err;
 }
 
+static uint16_t tuner_i2c_value_for_profile(const esp_rtl_sdr_handle *h)
+{
+    if (h != nullptr && h->profile == RtlHardwareProfile::NooelecSmartV5) {
+        return kR820T2TunerI2cValue;
+    }
+    return kBlogV4TunerI2cValue;
+}
+
+static RtlControlRecord map_tuner_record_for_profile(esp_rtl_sdr_handle *h,
+                                                     const RtlControlRecord &rec)
+{
+    RtlControlRecord mapped = rec;
+    const uint16_t tuner_addr = tuner_i2c_value_for_profile(h);
+    if (tuner_addr != kBlogV4TunerI2cValue &&
+        (mapped.index == 0x0610 || mapped.index == 0x0600) &&
+        (mapped.value & 0x00ffu) == kBlogV4TunerI2cValue) {
+        mapped.value = static_cast<uint16_t>((mapped.value & 0xff00u) | tuner_addr);
+    }
+    return mapped;
+}
+
 static esp_err_t run_record(esp_rtl_sdr_handle *h, const RtlControlRecord &rec,
                             bool expect_stall)
 {
-    return ctrl_submit(h, rec.request_type, 0, rec.value, rec.index, rec.data, rec.length,
-                       expect_stall);
+    const RtlControlRecord mapped = map_tuner_record_for_profile(h, rec);
+    return ctrl_submit(h, mapped.request_type, 0, mapped.value, mapped.index, mapped.data,
+                       mapped.length, expect_stall);
 }
 
 static esp_err_t run_init_table(esp_rtl_sdr_handle *h)
@@ -525,16 +559,39 @@ static esp_err_t run_sample_rate(esp_rtl_sdr_handle *h, uint32_t sample_rate_sps
  * Blog V4 HF (public): RF < 28.8 MHz is upconverted by 28.8 MHz before the tuner.
  * User-facing metrics keep RF; only the PLL pack uses tuner_hz.
  */
+static bool profile_supports_rf_hz(const esp_rtl_sdr_handle *h, uint32_t frequency_hz)
+{
+    if (h != nullptr && h->profile == RtlHardwareProfile::NooelecSmartV5 &&
+        frequency_hz < kR820T2NativeMinHz) {
+        return false;
+    }
+    return true;
+}
+
+static uint32_t tuner_frequency_hz_for_profile(const esp_rtl_sdr_handle *h, uint32_t rf_hz)
+{
+    if (h != nullptr && h->profile == RtlHardwareProfile::NooelecSmartV5) {
+        return rf_hz;
+    }
+    return esp_rtl_sdr_tuner_frequency_hz(rf_hz);
+}
+
 static esp_err_t run_tune(esp_rtl_sdr_handle *h, uint32_t frequency_hz)
 {
-    const uint32_t tuner_base = esp_rtl_sdr_tuner_frequency_hz(frequency_hz);
+    if (!profile_supports_rf_hz(h, frequency_hz)) {
+        ESP_LOGW(TAG, "Nooelec SMArt v5 HF/direct-sampling is not implemented rf=%u",
+                 static_cast<unsigned>(frequency_hz));
+        return ESP_RTL_SDR_ERR_BAD_FREQ;
+    }
+    const uint32_t tuner_base = tuner_frequency_hz_for_profile(h, frequency_hz);
     const uint32_t tune_hz =
         apply_freq_correction_hz(tuner_base, h != nullptr ? h->freq_correction_ppm : 0);
     uint8_t r16_setup = 0, r16_active = 0, r20 = 0, r21 = 0, r22 = 0;
     if (!encode_r820_pll(tune_hz, &r16_setup, &r16_active, &r20, &r21, &r22)) {
         return ESP_RTL_SDR_ERR_BAD_FREQ;
     }
-    const bool hf = esp_rtl_sdr_frequency_uses_hf_upconverter(frequency_hz);
+    const bool hf = h != nullptr && h->profile != RtlHardwareProfile::NooelecSmartV5 &&
+                    esp_rtl_sdr_frequency_uses_hf_upconverter(frequency_hz);
     ESP_LOGI(TAG,
              "tune rf=%u Hz tuner=%u Hz ppm=%d hf_upconv=%d r16=%02x/%02x r20=%02x r21=%02x r22=%02x",
              static_cast<unsigned>(frequency_hz), static_cast<unsigned>(tune_hz),
@@ -1355,19 +1412,33 @@ static void str_desc_ascii(const usb_str_desc_t *d, char *out, size_t out_sz)
     out[n] = '\0';
 }
 
-static bool accept_blog_v4(const usb_device_desc_t *dd, const usb_device_info_t *info,
-                           esp_rtl_sdr_device_info_t *out)
+static bool str_contains(const char *haystack, const char *needle)
 {
-    if (dd->idVendor != kVid || dd->idProduct != kPid) {
+    return haystack != nullptr && needle != nullptr && std::strstr(haystack, needle) != nullptr;
+}
+
+static bool identify_supported_profile(const usb_device_desc_t *dd, const usb_device_info_t *info,
+                                       esp_rtl_sdr_device_info_t *out,
+                                       RtlHardwareProfile *out_profile)
+{
+    if (dd->idVendor != kVid || dd->idProduct != kPid || out == nullptr || out_profile == nullptr) {
         return false;
     }
     char mfg[48]{}, prod[48]{}, ser[32]{};
     str_desc_ascii(info->str_desc_manufacturer, mfg, sizeof(mfg));
     str_desc_ascii(info->str_desc_product, prod, sizeof(prod));
     str_desc_ascii(info->str_desc_serial_num, ser, sizeof(ser));
-    if (std::strcmp(mfg, kMfg) != 0 || std::strcmp(prod, kProduct) != 0) {
+
+    RtlHardwareProfile profile = RtlHardwareProfile::BlogV4;
+    if (std::strcmp(mfg, kBlogV4Mfg) == 0 && std::strcmp(prod, kBlogV4Product) == 0) {
+        profile = RtlHardwareProfile::BlogV4;
+    } else if (std::strcmp(mfg, kNooelecMfg) == 0 &&
+               str_contains(prod, kNooelecSmartV5Product)) {
+        profile = RtlHardwareProfile::NooelecSmartV5;
+    } else {
         return false;
     }
+
     out->vid = dd->idVendor;
     out->pid = dd->idProduct;
     out->high_speed = (info->speed == USB_SPEED_HIGH);
@@ -1375,6 +1446,7 @@ static bool accept_blog_v4(const usb_device_desc_t *dd, const usb_device_info_t 
     std::snprintf(out->manufacturer, sizeof(out->manufacturer), "%s", mfg);
     std::snprintf(out->product, sizeof(out->product), "%s", prod);
     std::snprintf(out->serial, sizeof(out->serial), "%s", ser);
+    *out_profile = profile;
     return true;
 }
 
@@ -1389,6 +1461,7 @@ static bool probe_candidate(esp_rtl_sdr_handle *h, uint8_t addr, DeviceCandidate
     if (h->dev != nullptr && h->open_addr == addr) {
         out->addr = addr;
         out->info = h->info;
+        out->profile = h->profile;
         out->valid = true;
         return true;
     }
@@ -1404,17 +1477,20 @@ static bool probe_candidate(esp_rtl_sdr_handle *h, uint8_t addr, DeviceCandidate
         return false;
     }
     esp_rtl_sdr_device_info_t di{};
-    if (!accept_blog_v4(dd, &info, &di)) {
+    RtlHardwareProfile profile = RtlHardwareProfile::BlogV4;
+    if (!identify_supported_profile(dd, &info, &di, &profile)) {
         usb_host_device_close(h->client, dev);
         return false;
     }
     out->addr = addr;
     out->info = di;
+    out->profile = profile;
     out->valid = true;
     if (keep_open && h->dev == nullptr) {
         h->dev = dev;
         h->open_addr = addr;
         h->info = di;
+        h->profile = profile;
         return true;
     }
     usb_host_device_close(h->client, dev);
@@ -1583,6 +1659,7 @@ static void client_task_fn(void *arg)
                 h->open_addr = 0;
             }
             h->info.present = false;
+            h->profile = RtlHardwareProfile::BlogV4;
             h->state = ESP_RTL_SDR_STATE_IDLE;
             esp_rtl_sdr_event_cb_t cb = h->cfg.event_cb;
             void *ctx = h->cfg.event_ctx;
@@ -1691,8 +1768,8 @@ esp_err_t esp_rtl_sdr_install(const esp_rtl_sdr_config_t *config,
     h->state = ESP_RTL_SDR_STATE_IDLE;
     h->info.vid = kVid;
     h->info.pid = kPid;
-    std::snprintf(h->info.manufacturer, sizeof(h->info.manufacturer), "%s", kMfg);
-    std::snprintf(h->info.product, sizeof(h->info.product), "%s", kProduct);
+    std::snprintf(h->info.manufacturer, sizeof(h->info.manufacturer), "%s", kBlogV4Mfg);
+    std::snprintf(h->info.product, sizeof(h->info.product), "%s", kBlogV4Product);
 
     if (usb_host_transfer_alloc(kCtrlXferBytes, 0, &h->ctrl_xfer) != ESP_OK) {
         h->magic = 0;
@@ -2044,6 +2121,10 @@ esp_err_t esp_rtl_sdr_start(esp_rtl_sdr_handle_t handle,
         set_error_unlocked(handle, ESP_RTL_SDR_ERR_NO_DEVICE);
         return ESP_RTL_SDR_ERR_NO_DEVICE;
     }
+    if (!profile_supports_rf_hz(handle, freq)) {
+        set_error_unlocked(handle, ESP_RTL_SDR_ERR_BAD_FREQ);
+        return ESP_RTL_SDR_ERR_BAD_FREQ;
+    }
     handle->state = ESP_RTL_SDR_STATE_STARTING;
 
     /* USB work without holding API mutex across long EP0 sequences */
@@ -2191,6 +2272,10 @@ esp_err_t esp_rtl_sdr_retune_hz(esp_rtl_sdr_handle_t handle, uint32_t frequency_
         if (handle->state != ESP_RTL_SDR_STATE_STREAMING || !handle->streaming) {
             set_error_unlocked(handle, ESP_RTL_SDR_ERR_NOT_STREAMING);
             return ESP_RTL_SDR_ERR_NOT_STREAMING;
+        }
+        if (!profile_supports_rf_hz(handle, q)) {
+            set_error_unlocked(handle, ESP_RTL_SDR_ERR_BAD_FREQ);
+            return ESP_RTL_SDR_ERR_BAD_FREQ;
         }
         handle->pending_retune_hz = q;
         {
@@ -2650,6 +2735,7 @@ esp_err_t esp_rtl_sdr_select_device(esp_rtl_sdr_handle_t handle, size_t index)
             handle->dev = nullptr;
             handle->open_addr = 0;
             handle->info.present = false;
+            handle->profile = RtlHardwareProfile::BlogV4;
         }
         open_selected_candidate(handle, false); /* no callback under lock */
         if (handle->dev == nullptr) {
@@ -2721,6 +2807,7 @@ esp_err_t esp_rtl_sdr_select_device_serial(esp_rtl_sdr_handle_t handle, const ch
             handle->dev = nullptr;
             handle->open_addr = 0;
             handle->info.present = false;
+            handle->profile = RtlHardwareProfile::BlogV4;
         }
         open_selected_candidate(handle, false);
         if (handle->dev == nullptr) {

--- a/tests/host/test_policy.cpp
+++ b/tests/host/test_policy.cpp
@@ -661,6 +661,18 @@ static std::string slurp_repo_file(const char *rel)
                        std::istreambuf_iterator<char>());
 }
 
+
+static void test_nooelec_smart_v5_profile_scaffold(void)
+{
+    const std::string src = slurp_repo_file("src/esp_rtl_sdr.cpp");
+    EXPECT_TRUE(src.find("Nooelec") != std::string::npos);
+    EXPECT_TRUE(src.find("NESDR SMArt v5") != std::string::npos);
+    EXPECT_TRUE(src.find("kR820T2TunerI2cValue = 0x0034") != std::string::npos);
+    EXPECT_TRUE(src.find("map_tuner_record_for_profile") != std::string::npos);
+    EXPECT_TRUE(src.find("kR820T2NativeMinHz") != std::string::npos);
+    EXPECT_TRUE(src.find("HF/direct-sampling is not implemented") != std::string::npos);
+}
+
 static void test_smoke_urb_image_isolation(void)
 {
     const std::string cmake = slurp_repo_file("examples/p4_serial_smoke/CMakeLists.txt");
@@ -703,6 +715,7 @@ int main(void)
     test_usb_identity_constants();
     test_error_base_unique();
     test_metrics_window_health();
+    test_nooelec_smart_v5_profile_scaffold();
     test_smoke_urb_image_isolation();
     std::printf("RESULT passed=%d failed=%d\n", g_passed, g_failed);
     return g_failed == 0 ? 0 : 1;


### PR DESCRIPTION
Adds a clean-room, fail-closed Nooelec NESDR SMArt v5 / R820T2-R860 hardware profile for RTL2832U devices.

Summary:
- Recognizes the Nooelec/Realtek RTL2838UHIDIR descriptor path for USB VID:PID 0bda:2838.
- Adds a separate SMArt v5 hardware profile instead of treating it as RTL-SDR Blog V4.
- Maps the measured R82xx tuner-control path to R820T2/R860 I2C address 0x34 while keeping unsupported paths fail-closed.
- Documents provisional support status.

Tested:
- `tests/scripts/run_host_tests.sh` -> 297 passed, 0 failed.
- Built into OrcSDR Tab5 firmware and confirmed working by a tester from `hardcoreerik/OrcSDR#77`.

Context: hardcoreerik/OrcSDR#77


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added provisional support for detecting Nooelec NESDR SMArt v5 devices using the R820T2/R860 tuner profile.
  - Added profile-specific tuning and control handling for compatible devices.

- **Bug Fixes**
  - Frequencies below 24 MHz are now rejected for Nooelec devices because HF/direct sampling is not supported.

- **Documentation**
  - Updated the README, capability references, and changelog with Nooelec SMArt v5 setup details and current verification status.
  - Hardware support remains unverified pending physical testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->